### PR TITLE
improves emphasis for log out button verbiage

### DIFF
--- a/data-collection/data-collection/View Controllers/Drawer View Controller/DrawerViewController.swift
+++ b/data-collection/data-collection/View Controllers/Drawer View Controller/DrawerViewController.swift
@@ -217,7 +217,7 @@ class DrawerViewController: UIViewController {
     private func updateLoginButtonForAuthenticatedUsername(user: AGSPortalUser?) {
         
         if let currentUser = user {
-            loginButton.setAttributed(header: "Log out", subheader: currentUser.username, forControlStateColors: loginLogoutButtonControlStateColors, headerFont: .drawerButtonHeader, subheaderFont: .drawerButtonSubheader)
+            loginButton.setAttributed(header: currentUser.username ?? currentUser.email ?? "User", subheader: "Log out", forControlStateColors: loginLogoutButtonControlStateColors, headerFont: .drawerButtonHeader, subheaderFont: .drawerButtonSubheader)
         }
         else {
             loginButton.setAttributed(header: "Log in", forControlStateColors: loginLogoutButtonControlStateColors, headerFont: .drawerButtonHeader)


### PR DESCRIPTION
As per Sarat's app release review.

Now: places emphasis on username rather than 'Log out'. So, the header of the button is the current user's username and the subheader reads 'Log out'.