### PR TITLE
Improves UX when authenticating for world geocoder service.

### DIFF
--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+LocationSelection.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+LocationSelection.swift
@@ -136,6 +136,7 @@ extension MapViewController {
             return
         }
         
+        SVProgressHUD.setContainerView(self.view)
         SVProgressHUD.show(withStatus: "Preparing new \(newPopup.tableName ?? "record").")
         
         let centerPoint = mapView.centerAGSPoint
@@ -148,6 +149,7 @@ extension MapViewController {
             EphemeralCache.set(object: newPopup, forKey: EphemeralCacheKeys.newSpatialFeature)
             
             SVProgressHUD.dismiss()
+            SVProgressHUD.setContainerView(nil)
             
             self?.performSegue(withIdentifier: "modallyPresentRelatedRecordsPopupViewController", sender: nil)
         }


### PR DESCRIPTION
If a user has not authenticated and attempts to access the world geo-coder service, the ArcGIS Runtime SDK presents an authentication view controller modally. Now, setting the container view on the global SVProgressHUD ensures that the progress hud is presented within the view controller's view instead of on top of the window and no longer covers the presenting modal view controller.

To reproduce:
1. Launch app (using Trees of Portland).
2. Ensure user is logged out.
3. Add a new Tree feature.

When the authentication view controller presents, the ProgressHUD should no longer cover the presented view.