### PR TITLE
Forcibly removes credentials from geo-coder services.

### DIFF
--- a/data-collection/data-collection/AppContext/AppContext+Login.swift
+++ b/data-collection/data-collection/AppContext/AppContext+Login.swift
@@ -54,7 +54,7 @@ extension AppContext {
     func logout() {
         // We want to remove cached credentials upon logout.
         AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
-        // We want to remove cached credentials from geo-coder services
+        // We want to remove cached credentials from geo-coder services, in case they are cached.
         appReverseGeocoder.removeCredentialsFromServices()
         // Setting `loginRequired` to `false` will allow unauthenticated users to consume the map (but not edit!)
         portal = AppConfiguration.buildConfiguredPortal(loginRequired: false)

--- a/data-collection/data-collection/AppContext/AppContext+Login.swift
+++ b/data-collection/data-collection/AppContext/AppContext+Login.swift
@@ -54,6 +54,8 @@ extension AppContext {
     func logout() {
         // We want to remove cached credentials upon logout.
         AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
+        // We want to remove cached credentials from geo-coder services
+        appReverseGeocoder.removeCredentialsFromServices()
         // Setting `loginRequired` to `false` will allow unauthenticated users to consume the map (but not edit!)
         portal = AppConfiguration.buildConfiguredPortal(loginRequired: false)
     }

--- a/data-collection/data-collection/Geocode Search/AppReverseGeocoderManager.swift
+++ b/data-collection/data-collection/Geocode Search/AppReverseGeocoderManager.swift
@@ -51,6 +51,11 @@ class AppReverseGeocoderManager: AGSLoadableBase {
     // Offline locator using the side loaded 'AddressLocator'.
     private let offlineLocatorTask = AGSLocatorTask(name: "AddressLocator")
     
+    func removeCredentialsFromServices() {
+        onlineLocatorTask.credential = nil
+        offlineLocatorTask.credential = nil
+    }
+    
     override func doCancelLoading() {
         
         onlineLocatorTask.cancelLoad()


### PR DESCRIPTION
In case the services cache the previously used credentials. Now, with the geo-coder, we can guarantee the SDK to prompt for credentials when the user is not authenticated.

This can be tested following these steps:

1. Launch App (using Trees of Portland).
2. Log-in.
3. Add new Tree Feature.
_(App should not prompt for authentication)_
4. Log-out
5. Add new Tree Feature.
_(App should prompt for authentication)_