### PR TITLE
Removes ATS: allowing arbitrary loads and exception domains.

### DIFF
--- a/data-collection/Resources/Info.plist
+++ b/data-collection/Resources/Info.plist
@@ -35,28 +35,6 @@
 	<string>12</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>arcgis.com</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>arcgisonline.com</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
-	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Allow Data Collection to collect data near your location.</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
They are no longer needed since ArcGIS Online has updated the owning system URL.

This can be confirmed by checking [this URL](https://www.arcgis.com/sharing/rest/info?f=pjson) for key "owningSystemUrl". The url should use `https`.

To confirm this change works:

1. Launch App
2. Log-in to AGOL

This change works if no errors are thrown in Xcode.