### PR TITLE
Improves app custom behavior: Tree symbology updates despite zero inspections.

### DIFF
--- a/data-collection/data-collection/Custom Behavior/CustomBehavior_TreeSymbology.swift
+++ b/data-collection/data-collection/Custom Behavior/CustomBehavior_TreeSymbology.swift
@@ -56,12 +56,10 @@ func updateSymbology(withTreeManager treeManager: PopupRelatedRecordsManager, co
     if let newestInspection = inspectionsManager.relatedPopups.first,
         let newestInspectionFeature = newestInspection.geoElement as? AGSArcGISFeature,
         let newestInspectionFeatureTable = newestInspectionFeature.featureTable as? AGSArcGISFeatureTable,
-        newestInspectionFeatureTable.tableName == "Inspections",
-        newestInspectionFeature.attributes[conditionKey] != nil,
-        newestInspectionFeature.attributes[dbhKey] != nil {
+        newestInspectionFeatureTable.tableName == "Inspections" {
          // Update the condtion and dbh of the tree reflecting those of the newest inspection.
-        treeFeature.attributes[conditionKey] = newestInspectionFeature.attributes[conditionKey]
-        treeFeature.attributes[dbhKey] = newestInspectionFeature.attributes[dbhKey]
+        treeFeature.attributes[conditionKey] = newestInspectionFeature.attributes[conditionKey] ?? NSNull()
+        treeFeature.attributes[dbhKey] = newestInspectionFeature.attributes[dbhKey] ?? NSNull()
     }
     // Unless there is no newest inspection.
     else {


### PR DESCRIPTION
Changes update symbology custom behavior to update symbology when there are zero inspections for a tree.

To confirm this PR addresses the issue:

1. Launch app. (Using Trees of Portland, default)
2. Identify a tree on the map, ensure that tree has 1+ inspections.
_Note the color of the tree symbology_
3. Delete all of the inspections for that tree.
4. Return to the map view.

At this point the tree symbology should be black, representing no inspection.

If you add an inspection(s) to the tree, the symbology should reflect the color of the most recent inspection.
