### PR TITLE
Improves how the small pop-up view prioritizes label content.

### DIFF
--- a/data-collection/data-collection/AppConfiguration.swift
+++ b/data-collection/data-collection/AppConfiguration.swift
@@ -68,6 +68,7 @@ class AppConfiguration {
     /// The App's public client ID.
     /// - The client ID is used by oAuth to authenticate a user.
     /// - The client ID can be found in the **Credentials** section of the **Authentication** tab within the [Dashboard of the ArcGIS for Developers site](https://developers.arcgis.com/applications).
+    /// - Note: Change this to reflect your organization's client ID.
     static let clientID: String = "h3em0ifYNGfz3uHX"
 }
 

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.storyboard
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nEg-xi-PLM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nEg-xi-PLM">
     <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -74,7 +75,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XFk-gB-uaM">
                                         <rect key="frame" x="0.0" y="15" width="343" height="79"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Related Records Header" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qdc-PH-C8o">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Related Records Header" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.75" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qdc-PH-C8o">
                                                 <rect key="frame" x="16" y="8" width="257" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="mdu-Bd-2Vc"/>
@@ -83,13 +84,13 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Related Records Subheader" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6lj-pJ-A8j">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="A LONG ADDRESS COULD POSSIBLY " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.75" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6lj-pJ-A8j">
                                                 <rect key="frame" x="16" y="46" width="191" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="(n) Related Records" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yVa-3F-14f">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="(n) Related Records" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.75" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yVa-3F-14f">
                                                 <rect key="frame" x="207" y="46" width="120" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <nil key="textColor"/>
@@ -147,7 +148,7 @@
                                 </constraints>
                             </view>
                             <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JPL-Oj-pCs" customClass="PinDropView" customModule="data_collection" customModuleProvider="target">
-                                <rect key="frame" x="166.33333333333334" y="407.33333333333331" width="42" height="42"/>
+                                <rect key="frame" x="166.66666666666666" y="407" width="42" height="42"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="42" id="Vz9-Uy-yXm"/>
                                     <constraint firstAttribute="height" constant="42" id="aQQ-2p-xV5"/>

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.storyboard
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.storyboard
@@ -85,7 +85,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="A LONG ADDRESS COULD POSSIBLY " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.75" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6lj-pJ-A8j">
-                                                <rect key="frame" x="16" y="46" width="191" height="17"/>
+                                                <rect key="frame" x="16" y="46" width="187" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -99,7 +99,7 @@
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstItem="yVa-3F-14f" firstAttribute="leading" secondItem="6lj-pJ-A8j" secondAttribute="trailing" id="1CX-1k-No9"/>
+                                            <constraint firstItem="yVa-3F-14f" firstAttribute="leading" secondItem="6lj-pJ-A8j" secondAttribute="trailing" constant="4" id="1CX-1k-No9"/>
                                             <constraint firstItem="qdc-PH-C8o" firstAttribute="leading" secondItem="XFk-gB-uaM" secondAttribute="leading" constant="16" id="K8W-fV-ksf"/>
                                             <constraint firstItem="qdc-PH-C8o" firstAttribute="top" secondItem="XFk-gB-uaM" secondAttribute="top" constant="8" id="dy5-71-0Yh"/>
                                             <constraint firstItem="6lj-pJ-A8j" firstAttribute="top" secondItem="qdc-PH-C8o" secondAttribute="bottom" constant="8" id="eL2-vv-IXL"/>

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.storyboard
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.storyboard
@@ -84,7 +84,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="A LONG ADDRESS COULD POSSIBLY " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.75" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6lj-pJ-A8j">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Related Records Sub Header, Potentially Long!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.75" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6lj-pJ-A8j">
                                                 <rect key="frame" x="16" y="46" width="187" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <nil key="textColor"/>


### PR DESCRIPTION
Small pop-up view: assigns higher horizontal compression resistance to (n) related records than that of the address label.

Before:
![screen shot 2018-09-28 at 5 43 27 pm](https://user-images.githubusercontent.com/33433113/46238917-45254e80-c346-11e8-9367-b44ae5dce77e.png)

After:
![screen shot 2018-09-28 at 5 44 20 pm](https://user-images.githubusercontent.com/33433113/46238918-48b8d580-c346-11e8-89df-f9ea0034bd59.png)
