### PR TITLE
Users parameter/parameters markup elements

### DIFF
--- a/data-collection/data-collection/Custom Behavior/CustomBehavior_IdentifyNeighborhood.swift
+++ b/data-collection/data-collection/Custom Behavior/CustomBehavior_IdentifyNeighborhood.swift
@@ -20,11 +20,10 @@ import ArcGIS
 /// When creating a new tree, this function queries the neighbhoords layer to populate the created tree's
 /// attributes dictionary with the resulting neighborhood's name.
 ///
-/// - Param:
+/// - Parameters:
 ///     - popup: The new tree.
 ///     - point: The point used in the spatial query.
 ///     - completion: The callback called upon completion. The operation is successful or fails, silently.
-
 func enrich(popup: AGSPopup, withNeighborhoodIdentifyForPoint point: AGSPoint, completion: @escaping () -> Void) {
     
     guard let map = appContext.currentMap else {

--- a/data-collection/data-collection/Custom Behavior/CustomBehavior_NewTreeCondition.swift
+++ b/data-collection/data-collection/Custom Behavior/CustomBehavior_NewTreeCondition.swift
@@ -20,9 +20,7 @@ import ArcGIS
 /// When creating a new tree, this function populates the condition attribute with a default value. 
 /// The default value is "good".
 ///
-/// - Param:
-///     - popup: The new tree.
-
+/// - Parameters popup: The new tree.
 func configureDefaultCondition(forPopup popup: AGSPopup) {
     
     let conditionKey = "Condition"

--- a/data-collection/data-collection/Custom Behavior/CustomBehavior_ReverseGeocode.swift
+++ b/data-collection/data-collection/Custom Behavior/CustomBehavior_ReverseGeocode.swift
@@ -19,11 +19,10 @@ import ArcGIS
 ///
 /// When creating a new tree, this function uses a geocoder to reverse-geocode an address, provided a point.
 ///
-/// - Param:
+/// - Parameters:
 ///     - popup: The new tree.
 ///     - point: The point used to reverse-geocode for an address.
 ///     - completion: The callback called upon completion. The operation finishes successfully or fails, silently.
-
 func enrich(popup: AGSPopup, withReverseGeocodedDataForPoint point: AGSPoint, completion: @escaping () -> Void) {
     
     let addressKey = "Address"

--- a/data-collection/data-collection/Custom Behavior/CustomBehavior_TreeSymbology.swift
+++ b/data-collection/data-collection/Custom Behavior/CustomBehavior_TreeSymbology.swift
@@ -20,10 +20,9 @@ import ArcGIS
 /// When creating or updating an inspection, this function is used to update the symbology of the parent tree
 /// according to which inspection's date is newest.
 ///
-/// - Param:
+/// - Parameters:
 ///     - treeManager: The tree's manager object.
 ///     - completion: The callback called upon completion. The operation is successful or fails, silently.
-
 func updateSymbology(withTreeManager treeManager: PopupRelatedRecordsManager, completion: @escaping () -> Void) {
     
     // This function will be called only after the inspections array has been sorted by inspection date


### PR DESCRIPTION
This allows the parameter documentation to be parsed and shown in the correct place in quick help.

Before | After
------ | -----
<img width="514" alt="screen shot 2018-10-05 at 1 34 34 pm" src="https://user-images.githubusercontent.com/2257493/46559252-a5674380-c8a4-11e8-8c37-bfeaaac50512.png">|<img width="516" alt="screen shot 2018-10-05 at 1 35 00 pm" src="https://user-images.githubusercontent.com/2257493/46559229-97b1be00-c8a4-11e8-878a-7d1ff6d62e72.png">
