### PR TITLE
Updates app to build for 100.4

### DIFF
--- a/sdk_build
+++ b/sdk_build
@@ -1,2 +1,2 @@
 # Note: This build number is used for Esri internal development purposes and can be ignored.
-2196
+2207


### PR DESCRIPTION
Sets Jenkins SDK build number to public `100.4.0`.
App functionality performs as expected.