### PR TITLE
Updates AGSArcGISFeature deprecated method.

### DIFF
--- a/data-collection/data-collection/Extensions/ArcGIS/AGSArcGISFeatureTable/AGSArcGISFeatureTable+Edit.swift
+++ b/data-collection/data-collection/Extensions/ArcGIS/AGSArcGISFeatureTable/AGSArcGISFeatureTable+Edit.swift
@@ -80,7 +80,7 @@ extension AGSArcGISFeatureTable {
             
             let updateObjectID: () -> Void = {
                 if type != .delete {
-                    feature.refreshObjectID()
+                    feature.refresh()
                 }
                 else {
                     feature.objectID = nil


### PR DESCRIPTION
`refreshObjectID()` -> `refresh()` starting in `100.4.0`.