### PR TITLE
Add Related Record Button Bugfix

### DIFF
--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+SmallPopupView.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+SmallPopupView.swift
@@ -61,10 +61,11 @@ extension MapViewController {
                 self?.relatedRecordsNLabel.text = fallbackPopupManager?.nextDisplayFieldStringValue(fieldIndex: &fallbackIndex)
             }
             
-            self?.addPopupRelatedRecordButton.isHidden = true
-            
             if let canAdd = self?.recordsManager?.oneToMany.first?.relatedTable?.canAddFeature {
                 self?.addPopupRelatedRecordButton.isHidden = !canAdd
+            }
+            else {
+                self?.addPopupRelatedRecordButton.isHidden = true
             }
             
             self?.mapViewMode = .selectedFeature(featureLoaded: true)

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+SmallPopupView.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+SmallPopupView.swift
@@ -61,7 +61,7 @@ extension MapViewController {
                 self?.relatedRecordsNLabel.text = fallbackPopupManager?.nextDisplayFieldStringValue(fieldIndex: &fallbackIndex)
             }
             
-            self?.addPopupRelatedRecordButton.isHidden = false
+            self?.addPopupRelatedRecordButton.isHidden = true
             
             if let canAdd = self?.recordsManager?.oneToMany.first?.relatedTable?.canAddFeature {
                 self?.addPopupRelatedRecordButton.isHidden = !canAdd


### PR DESCRIPTION
Defaults add related record button to hidden- unless first one to many related record table can add feature.

See issue: https://github.com/Esri/data-collection-ios/issues/139