### PR TITLE
Refreshes MapViewController for newly set portal

### DIFF
--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.swift
@@ -226,6 +226,8 @@ class MapViewController: UIViewController {
         }
         
         let currentPortalChange: AppContextChange = .currentPortal { [weak self] portal in
+            self?.mapViewMode = .defaultView
+            self?.currentPopup = nil
             self?.loadMapViewMap()
         }
 


### PR DESCRIPTION
When a new portal is set, the map view controller refreshes it's `mapViewMode` and `currentPopup`.