### PR TITLE
Login for Private Resources

### DIFF
--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+Map.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+Map.swift
@@ -38,7 +38,7 @@ extension MapViewController {
                     self?.present(loginAlertMessage: "You must log in to access this resource.")
                 }
                 else {
-                    self?.present(simpleAlertMessage: "Couldn't load map. \(error.localizedDescription).")
+                    self?.present(simpleAlertMessage: error.localizedDescription)
                 }
                 
                 self?.mapViewMode = .disabled


### PR DESCRIPTION
Now, only the login alert message will present if the app does not have an authenticated user.

References: https://github.com/Esri/data-collection-ios/issues/149

To test, temporarily swap `AppConfiguration.webMapItemID` for `1300bf23f97f4a2bb6ede795dfab8b72 `.

Then, test this behavior has been enacted correctly by logging in to AGOL with an account that is not a part of the Runtime organization.

To get credentials for an AGOL account that is not a part of the Runtime organization, DM me (Eli).