### PR TITLE
Supports all static image types retrieved from UIImagePickerController

### DIFF
--- a/data-collection/data-collection/Rich Popup/Attachments/RichPopupAttachmentsManager.swift
+++ b/data-collection/data-collection/Rich Popup/Attachments/RichPopupAttachmentsManager.swift
@@ -124,8 +124,6 @@ class RichPopupAttachmentsManager: AGSLoadableBase {
         
         let dispatchGroup = DispatchGroup()
         
-        dispatchGroup.enter()
-        
         newAttachments.forEach { (attachment) in
 
             if let photoAttachment = attachment as? RichPopupStagedPhotoAttachment {
@@ -153,8 +151,6 @@ class RichPopupAttachmentsManager: AGSLoadableBase {
             
             completion()
         }
-        
-        dispatchGroup.leave()        
     }
         
     func discardStagedAttachments() {

--- a/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedPhotoAttachment.swift
+++ b/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedPhotoAttachment.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import ArcGIS
-import Photos
 
 class RichPopupStagedPhotoAttachment: RichPopupStagedAttachment {
     
@@ -38,7 +37,7 @@ class RichPopupStagedPhotoAttachment: RichPopupStagedAttachment {
 
         guard (info[.editedImage] as? UIImage ?? info[.originalImage] as? UIImage) != nil else { return nil }
         
-        super.init(data: Data(), mimeType: "<will-be-inferred>", name: nil)
+        super.init(data: Data() /* will be inferred by SDK */, mimeType: "<will-be-inferred-by-SDK>", name: nil)
         
         self.previewItemURL = info[.imageURL] as? URL
         

--- a/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedPhotoAttachment.swift
+++ b/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedPhotoAttachment.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import ArcGIS
+import Photos
 
 class RichPopupStagedPhotoAttachment: RichPopupStagedAttachment {
     
@@ -25,45 +26,23 @@ class RichPopupStagedPhotoAttachment: RichPopupStagedAttachment {
     
     override var type: AGSPopupAttachmentType { return .image }
     
-    let image: UIImage
-    
-    var nameAsJPEG: String? {
-        
-        guard var jpegName = name?.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
-        
-        let fileExtension = (jpegName as NSString).pathExtension
-        
-        if jpegName.isEmpty {
-            jpegName.append("Image")
-        }
-        
-        if fileExtension != "jpeg" && fileExtension != "jpg" {
-            jpegName.append(".jpeg")
-        }
-        
-        return jpegName
+    var image: UIImage {
+        return info[.editedImage] as? UIImage ?? info[.originalImage] as! UIImage
     }
     
-    init?(image: UIImage) {
-        
-        self.image = image
-        
-        guard let data = image.jpegData(compressionQuality: 1.0) else { return nil }
-        
-        super.init(data: data, mimeType: "image/jpeg", name: nil)
-        
-        setAttachmentNameIncrementedNext()
-    }
+    let info: [UIImagePickerController.InfoKey : Any]
     
-    convenience init?(imagePickerMediaInfo info: [UIImagePickerController.InfoKey : Any]) {
+     init?(imagePickerMediaInfo info: [UIImagePickerController.InfoKey : Any]) {
         
-        guard let image = info[.editedImage] as? UIImage ?? info[.originalImage] as? UIImage else {
-            return nil
-        }
+        self.info = info
+
+        guard (info[.editedImage] as? UIImage ?? info[.originalImage] as? UIImage) != nil else { return nil }
         
-        self.init(image: image)
+        super.init(data: Data(), mimeType: "<will-be-inferred>", name: nil)
         
         self.previewItemURL = info[.imageURL] as? URL
+        
+        setAttachmentNameIncrementedNext()
     }
     
     override func generateThumbnail(withSize: Float, scaleMode: AGSImageScaleMode, completion: @escaping (UIImage?) -> Void) {

--- a/data-collection/data-collection/Rich Popup/RichPopupManager.swift
+++ b/data-collection/data-collection/Rich Popup/RichPopupManager.swift
@@ -133,7 +133,7 @@ class RichPopupManager: AGSPopupManager {
             }
         }
         
-        func finish() {
+        let finish: () -> Void = {
             // Finally, the manager finishes editing it's attributes.
             super.finishEditing { (error) in
                 

--- a/data-collection/data-collection/Rich Popup/RichPopupManager.swift
+++ b/data-collection/data-collection/Rich Popup/RichPopupManager.swift
@@ -133,22 +133,31 @@ class RichPopupManager: AGSPopupManager {
             }
         }
         
-        // Then, commit all staged (add/delete) attachments.
-        richPopupAttachmentManager?.commitStagedAttachments()
+        func finish() {
+            // Finally, the manager finishes editing it's attributes.
+            super.finishEditing { (error) in
+                
+                if let error = error {
+                    relatedRecordsErrors.append(error)
+                }
+                
+                if !relatedRecordsErrors.isEmpty {
+                    completion(RichPopupManagerError.invalidPopup(relatedRecordsErrors))
+                }
+                else {
+                    completion(nil)
+                }
+            }
+        }
         
-        // Finally, the manager finishes editing it's attributes.
-        super.finishEditing { (error) in
-            
-            if let error = error {
-                relatedRecordsErrors.append(error)
+        // Then, commit all staged (add/delete) attachments.
+        if let attachmentsManager = richPopupAttachmentManager {
+            attachmentsManager.commitStagedAttachments {
+                finish()
             }
-
-            if !relatedRecordsErrors.isEmpty {
-                completion(RichPopupManagerError.invalidPopup(relatedRecordsErrors))
-            }
-            else {
-                completion(nil)
-            }
+        }
+        else {
+            finish()
         }
     }
     


### PR DESCRIPTION
Implements adding photo attachment using [addAttachmentWithUIImagePickerControllerInfoDictionary](https://developers.arcgis.com/ios/latest/api-reference/interface_a_g_s_popup_attachment_manager.html#a23bfef7aaa1e99770ccc6c9566cb4ade) rather than [addAttachmentAsJPGWithImage](https://developers.arcgis.com/ios/latest/api-reference/interface_a_g_s_popup_attachment_manager.html#a9606cea7ec9b1a1d20cd5da1e52e15a4).

See https://github.com/Esri/data-collection-ios/issues/171