### PR TITLE
Use implementation of hash(into:) provided by the standard library

### DIFF
--- a/data-collection/data-collection/Extensions/UIKit/UIControlState/UIControlState+Hashable.swift
+++ b/data-collection/data-collection/Extensions/UIKit/UIControlState/UIControlState+Hashable.swift
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
 import UIKit.UIControl
 
-extension UIControl.State: Hashable {
-    // Conforms `UIControlState` to `Hashable` so that a control state can be used as a Dictionary key.
-    public var hashValue: Int {
-        return Int(rawValue)
-    }
-}
+// Conforms `UIControl.State` to `Hashable` so that a control state can be used
+// as a Dictionary key.
+extension UIControl.State: Hashable {}


### PR DESCRIPTION
`Hashable.hashValue` has been deprecated. The replacement is `hash(into:)`, which could be implemented as follows:

```swift
public func hash(into hasher: inout Hasher) {
    hasher.combine(rawValue)
}
```

However, the standard library provides an implementation. From the documentation for `RawRepresentable` (to which `UIControl.State` conforms): "Available when `Self` conforms to `Hashable` and `RawValue` conforms to `Hashable`."