### PR TITLE
Small pop-up view touch-drag event dismiss behavior

### DIFF
--- a/data-collection/data-collection/Custom Views/ShrinkingView.swift
+++ b/data-collection/data-collection/Custom Views/ShrinkingView.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-protocol ShrinkingViewDelegate {
+protocol ShrinkingViewDelegate: class {
     func shrinkingViewDidDragWith(yDelta: CGFloat)
     func shrinkingViewDidFinishDrag(thresholdReached: Bool)
 }
@@ -45,10 +45,10 @@ class ShrinkingView: UIControl {
     
     // MARK:- Drag Y Offset
     
-    var delegate: ShrinkingViewDelegate?
+    weak var delegate: ShrinkingViewDelegate?
 
     private struct DragThreshold {
-        static let yOffset: CGFloat = 60
+        static let yOffset: CGFloat = 12
     }
     
     private var touchDownPoint: CGPoint?
@@ -118,8 +118,12 @@ class ShrinkingView: UIControl {
             
             let delta = touchDownPoint.y - currentLocation.y
             
-            if delta >= DragThreshold.yOffset || delta <= -DragThreshold.yOffset {
+            if delta <= -DragThreshold.yOffset {
                 delegate?.shrinkingViewDidFinishDrag(thresholdReached: true)
+                return
+            }
+            if delta >= DragThreshold.yOffset {
+                delegate?.shrinkingViewDidFinishDrag(thresholdReached: false)
                 return
             }
         }

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+MapViewMode.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+MapViewMode.swift
@@ -17,9 +17,7 @@ import UIKit
 extension MapViewController {
     
     func adjustForMapViewMode(from: MapViewMode?, to: MapViewMode) {
-        
-        if let from = from, from == to { return }
-        
+                
         let smallPopViewVisible: (Bool) -> UIViewAnimations = { [weak self] (visible) in
             return {
                 guard let self = self else { return }

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+MapViewMode.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+MapViewMode.swift
@@ -22,7 +22,7 @@ extension MapViewController {
             return {
                 guard let self = self else { return }
                 self.smallPopupView.alpha = CGFloat(visible)
-                self.featureDetailViewBottomConstraint.constant = visible ? 8 : 28
+                self.featureDetailViewBottomConstraint.constant = visible ? 8 : -156
             }
         }
         

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+Setup.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+Setup.swift
@@ -53,8 +53,4 @@ extension MapViewController {
         featureDetailViewBottomConstraint = mapView.attributionTopAnchor.constraint(equalTo: smallPopupView.bottomAnchor, constant: 8)
         featureDetailViewBottomConstraint.isActive = true
     }
-    
-    func setupSmallPopupView() {
-        smallPopupView.addTarget(self, action: #selector(MapViewController.didTapSmallPopupView(_:)), for: .touchUpInside)
-    }
 }

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+SmallPopupView.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+SmallPopupView.swift
@@ -44,9 +44,18 @@ extension MapViewController {
         performSegue(withIdentifier: "modallyPresentRelatedRecordsPopupViewController", sender: nil)
     }
     
+    @objc func appWillResignActive(notification: Notification) {
+        guard case MapViewMode.selectedFeature(featureLoaded: true) = mapViewMode else { return }
+        mapViewMode = .selectedFeature(featureLoaded: true)
+    }
+    
     func setupSmallPopupView() {
         smallPopupView.delegate = self
         smallPopupView.addTarget(self, action: #selector(MapViewController.didTapSmallPopupView(_:)), for: .touchUpInside)
+        appNotificationCenter.addObserver(self,
+                                          selector: #selector(appWillResignActive),
+                                          name: UIApplication.willResignActiveNotification,
+                                          object: nil)
     }
     
     func refreshCurrentPopup() {

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+SmallPopupView.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+SmallPopupView.swift
@@ -15,11 +15,38 @@
 import UIKit
 import ArcGIS
 
+extension MapViewController: ShrinkingViewDelegate {
+    
+    func shrinkingViewDidDragWith(yDelta: CGFloat) {
+        
+        guard case MapViewMode.selectedFeature(true) = mapViewMode else { return }
+        
+        featureDetailViewBottomConstraint.constant = yDelta + 8
+    }
+    
+    func shrinkingViewDidFinishDrag(thresholdReached: Bool) {
+        
+        if thresholdReached {
+            self.clearCurrentPopup()
+            self.mapViewMode = .defaultView
+        }
+        else {
+            self.mapViewMode = .selectedFeature(featureLoaded: true)
+        }
+    }
+}
+
 extension MapViewController {
+    
     
     @objc func didTapSmallPopupView(_ sender: Any) {
         guard currentPopupManager != nil else { return }
         performSegue(withIdentifier: "modallyPresentRelatedRecordsPopupViewController", sender: nil)
+    }
+    
+    func setupSmallPopupView() {
+        smallPopupView.delegate = self
+        smallPopupView.addTarget(self, action: #selector(MapViewController.didTapSmallPopupView(_:)), for: .touchUpInside)
     }
     
     func refreshCurrentPopup() {

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.storyboard
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nEg-xi-PLM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nEg-xi-PLM">
     <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/sdk_build
+++ b/sdk_build
@@ -1,2 +1,2 @@
 # Note: This build number is used for Esri internal development purposes and can be ignored.
-2377
+2454


### PR DESCRIPTION
The lack of this feature has bugged me for a while. Before now, to dismiss a currently selected pop-up, a user would have to select an area of the map where there are no identifiable features. Now the user can touch-drag up or down past a threshold (of 60 points) to dismiss the small pop-up view.

Asking for review from @philium and @nixta for code quality and from @mikewilburn for usability. Of course, these review delineations can blur, if you like.