### PR TITLE
Update app to swift 5.1

### DIFF
--- a/data-collection/data-collection/AppLocation.swift
+++ b/data-collection/data-collection/AppLocation.swift
@@ -66,6 +66,8 @@ extension CLAuthorizationStatus: CustomStringConvertible {
             return "Not Determined"
         case .restricted:
             return "Restricted"
+        @unknown default:
+            fatalError("Unsupported case \(self).")
         }
     }
 }

--- a/data-collection/data-collection/Extensions/ArcGIS/AGSDrawStatus/AGSDrawStatus+CustomStringConvertible.swift
+++ b/data-collection/data-collection/Extensions/ArcGIS/AGSDrawStatus/AGSDrawStatus+CustomStringConvertible.swift
@@ -27,6 +27,8 @@ extension AGSDrawStatus: CustomStringConvertible {
             return "Completed"
         case .inProgress:
             return "In Progress"
+        @unknown default:
+            fatalError("Unsupported case \(self).")
         }
     }
 }

--- a/data-collection/data-collection/Extensions/ArcGIS/AGSJobStatus/AGSJobStatus+CustomStringConvertible.swift
+++ b/data-collection/data-collection/Extensions/ArcGIS/AGSJobStatus/AGSJobStatus+CustomStringConvertible.swift
@@ -33,6 +33,8 @@ extension AGSJobStatus: CustomStringConvertible {
             return "Succeeded"
         case .failed:
             return "Failed"
+        @unknown default:
+            fatalError("Unsupported case \(self).")
         }
     }
 }

--- a/data-collection/data-collection/Extensions/ArcGIS/AGSLicense/AGSLicense+Description.swift
+++ b/data-collection/data-collection/Extensions/ArcGIS/AGSLicense/AGSLicense+Description.swift
@@ -44,6 +44,8 @@ extension AGSLicense {
             case .invalid:
                 // Not a valid license. Expiration means nothing.
                 return "\(self.licenseStatus)"
+            @unknown default:
+                fatalError("Unsupported case \(self).")
             }
         } else {
             // No expiry…
@@ -78,6 +80,8 @@ extension AGSLicenseLevel : CustomStringConvertible {
             return "Standard"
         case .advanced:
             return "Advanced"
+        @unknown default:
+            fatalError("Unsupported case \(self).")
         }
     }
 }
@@ -93,6 +97,8 @@ extension AGSLicenseStatus : CustomStringConvertible {
             return "Expired"
         case .loginRequired:
             return "Login Required"
+        @unknown default:
+            fatalError("Unsupported case \(self).")
         }
     }
 }
@@ -106,6 +112,8 @@ extension AGSLicenseType : CustomStringConvertible {
             return "Named User"
         case .licenseKey:
             return "License Key"
+        @unknown default:
+            fatalError("Unsupported case \(self).")
         }
     }
 }

--- a/data-collection/data-collection/Extensions/ArcGIS/AGSLoadStatus/AGSLoadStatus+CustomStringConvertible.swift
+++ b/data-collection/data-collection/Extensions/ArcGIS/AGSLoadStatus/AGSLoadStatus+CustomStringConvertible.swift
@@ -33,6 +33,8 @@ extension AGSLoadStatus: CustomStringConvertible {
             return "Not Loaded"
         case .unknown:
             return "Unknown"
+        @unknown default:
+            fatalError("Unsupported case \(self).")
         }
     }
 }

--- a/data-collection/data-collection/Extensions/ArcGIS/AGSPopup/AGSPopup+Sort.swift
+++ b/data-collection/data-collection/Extensions/ArcGIS/AGSPopup/AGSPopup+Sort.swift
@@ -36,6 +36,8 @@ extension Array where Element == AGSPopup {
                     return try left > right
                 }
             }
+        @unknown default:
+            fatalError("Unsupported case \(self).")
         }
     }
 }

--- a/data-collection/data-collection/Extensions/ArcGIS/AGSPopupAttachmentSize/AGSPopupAttachmentSize+String.swift
+++ b/data-collection/data-collection/Extensions/ArcGIS/AGSPopupAttachmentSize/AGSPopupAttachmentSize+String.swift
@@ -28,6 +28,8 @@ extension AGSPopupAttachmentSize {
             return CGSize(width: 960, height: 1280)
         case .extraLarge:
             return CGSize(width: 1126, height: 1500)
+        @unknown default:
+            fatalError("Unsupported case \(self).")
         }
     }
     
@@ -60,6 +62,8 @@ extension AGSPopupAttachmentSize {
             return "Extra Large \(width)x\(height)"
         case .actual:
             return "Actual Size (full resolution)"
+        @unknown default:
+            fatalError("Unsupported case \(self).")
         }
     }
 }

--- a/data-collection/data-collection/Extensions/ArcGIS/AGSPopupAttachmentType/AGSPopupAttachmentType+Icon.swift
+++ b/data-collection/data-collection/Extensions/ArcGIS/AGSPopupAttachmentType/AGSPopupAttachmentType+Icon.swift
@@ -26,6 +26,8 @@ extension AGSPopupAttachmentType {
             return #imageLiteral(resourceName: "AttachmentDocument")
         case .other:
             return #imageLiteral(resourceName: "AttachmentOther")
+        @unknown default:
+            fatalError("Unsupported case \(self).")
         }
     }
 }

--- a/data-collection/data-collection/Extensions/UIKit/UIView/UIView+StackViewAutoLayout.swift
+++ b/data-collection/data-collection/Extensions/UIKit/UIView/UIView+StackViewAutoLayout.swift
@@ -47,6 +47,9 @@ extension UIView {
             case .vertical:
                 top.priority = UILayoutPriority(999)
                 bottom.priority = UILayoutPriority(999)
+                
+            @unknown default:
+                fatalError("Unsupported case \(self).")
             }
         }
 


### PR DESCRIPTION
Now triggers fatal error for unsupported enum cases.