### PR TITLE
Consider new modal presentation dismissal regarding rich pop-up view controller editing

### DIFF
--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController.swift
@@ -186,6 +186,12 @@ class RichPopupViewController: SegmentedViewController {
             self.navigationItem.leftBarButtonItem = self.dismissButton
         }
         
+        // Because iOS 13 introduces a new modal dismissal paradigm (swipe-down),
+        // we need to inform the view controller not to dismiss the view controller if editing.
+        if #available(iOS 13.0, *) {
+            isModalInPresentation = self.popupManager.isEditing
+        }
+        
         // If this is a newly added record, we will need to add a delete button.
         conditionallyAddDeleteButton()
     }


### PR DESCRIPTION
Because iOS 13 introduces a new modal presentation design, we need to specify if the rich pop-up view controller can be swipe-dismissed or not. We want to allow swipe-dismiss if the user is not editing the rich pop-up and disallow swipe-dismiss if the user is editing the rich pop-up.

_Note. Xcode 11 beta is required to compile this change._