### PR TITLE
popover attachment issue

### DIFF
--- a/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
+++ b/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
@@ -174,7 +174,7 @@ public struct ImagePickerPermissions {
         
         let viewController = delegate.imagePickerPermissionsRequestsPresentingViewController()
         
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
         
         for permission in permissions {
             
@@ -186,7 +186,7 @@ public struct ImagePickerPermissions {
         }
         
         alertController.addAction(.cancel())
-        
+
         viewController.present(alertController, animated: true)
     }
 }

--- a/data-collection/data-collection/View Controllers/App Container/AppContainerViewController.swift
+++ b/data-collection/data-collection/View Controllers/App Container/AppContainerViewController.swift
@@ -124,7 +124,7 @@ class AppContainerViewController: UIViewController {
     }
     
     @IBAction func userTapsRightButton(_ sender: Any) {
-        mapViewController?.userRequestsAddNewFeature()
+        mapViewController?.userRequestsAddNewFeature(sender as? UIBarButtonItem)
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+LocationSelection.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+LocationSelection.swift
@@ -43,7 +43,7 @@ extension MapViewController {
     
     // MARK : New Feature
     
-    func userRequestsAddNewFeature() {
+    func userRequestsAddNewFeature(_ barButtonItem: UIBarButtonItem?) {
         
         guard mapViewMode != .disabled else {
             return
@@ -78,6 +78,7 @@ extension MapViewController {
             
             action.addAction(.cancel())
             
+            action.popoverPresentationController?.barButtonItem = barButtonItem
             present(action, animated: true, completion: nil)
         }
     }


### PR DESCRIPTION
https://github.com/Esri/data-collection-ios/issues/209

Resolution was to pass the `UIBarButtonItem` along to the `userRequestsAddNewFeature` method for selecting a layer to add the new feature too.

For the image source selection, the `UIAlertController` was changed from a `.actionSheet` to a `.alert` as there was no appropriate, easily-accessible UI component to use as a source view/rect.