### PR TITLE
Avoid nullify map if user cancelled Log in

### DIFF
--- a/data-collection/data-collection/App Context/AppContext.swift
+++ b/data-collection/data-collection/App Context/AppContext.swift
@@ -40,7 +40,8 @@ import ArcGIS
 
                 guard error == nil else {
                     print("[Error: Portal Load Status]", error!.localizedDescription)
-                    if self.workMode == .online {
+                    let isUserCanceledError = (error as NSError?)?.code == 3072
+                    if self.workMode == .online && !isUserCanceledError {
                         self.currentMap = nil
                     }
                     return

--- a/data-collection/data-collection/App Context/AppContext.swift
+++ b/data-collection/data-collection/App Context/AppContext.swift
@@ -40,7 +40,7 @@ import ArcGIS
 
                 guard error == nil else {
                     print("[Error: Portal Load Status]", error!.localizedDescription)
-                    let isUserCanceledError = (error as NSError?)?.code == 3072
+                    let isUserCanceledError = (error as NSError?)?.code == NSUserCancelledError
                     if self.workMode == .online && !isUserCanceledError {
                         self.currentMap = nil
                     }
@@ -103,4 +103,3 @@ import ArcGIS
         }
     }
 }
-


### PR DESCRIPTION
Avoid nullify map if user cancelled Log in OAuth process. Otherwise user need to kill the app and launch it again in order to be able to continue using it.