### PR TITLE
App configuration: brevity

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 - Improves some organization of the code.
 - Fix build-time warning when building with XCode 11.4 (in LoadableErrors.swift).
 - Adds Alamofire dependency as a Swift Package. Updates using the latest `NetworkReachabilityManager` API.
+- Improves how the app maintains static configurations.
 - Certification for the 100.8.0 release of the ArcGIS Runtime SDK for iOS.
 
 # Release 1.1.4

--- a/data-collection/data-collection/App Context/AppContext+Login.swift
+++ b/data-collection/data-collection/App Context/AppContext+Login.swift
@@ -45,7 +45,7 @@ extension AppContext {
     /// - Note: The ArcGIS Runtime SDK will present a modal sign-in web view if it cannot find any suitable cached credentials.
     func signIn() { 
         // Setting `loginRequired` to `true` will force a sign-in prompt to present.
-        portal = AppConfiguration.buildConfiguredPortal(loginRequired: true)
+        portal = AGSPortal.configuredPortal(loginRequired: true)
     }
     
     /// Log out in the app and from the portal.
@@ -57,6 +57,6 @@ extension AppContext {
         // We want to remove cached credentials from geo-coder services, in case they are cached.
         appReverseGeocoder.removeCredentialsFromServices()
         // Setting `loginRequired` to `false` will allow unauthenticated users to consume the map (but not edit!)
-        portal = AppConfiguration.buildConfiguredPortal(loginRequired: false)
+        portal = AGSPortal.configuredPortal(loginRequired: false)
     }
 }

--- a/data-collection/data-collection/App Context/AppContext+VisibleArea.swift
+++ b/data-collection/data-collection/App Context/AppContext+VisibleArea.swift
@@ -17,7 +17,7 @@ import ArcGIS
 
 extension AppContext {
     
-    private var visibleAreaDefaultsKey: String { return "VisibleAreaDefaultsKey.\(AppConfiguration.webMapItemID)" }
+    private var visibleAreaDefaultsKey: String { return "VisibleAreaDefaultsKey.\(String.webMapItemID)" }
     
     /// The shared visible area `AGSViewpoint`.
     ///

--- a/data-collection/data-collection/App Context/AppContext+WorkMode.swift
+++ b/data-collection/data-collection/App Context/AppContext+WorkMode.swift
@@ -23,7 +23,7 @@ enum WorkMode: Int {
     case online = 1
     case offline
     
-    private static let userDefaultsKey = "WorkMode.\(AppConfiguration.webMapItemID)"
+    private static let userDefaultsKey = "WorkMode.\(String.webMapItemID)"
     
     func storeDefaultWorkMode() {
         UserDefaults.standard.set(self.rawValue, forKey: WorkMode.userDefaultsKey)
@@ -75,8 +75,10 @@ extension AppContext {
     /// Load the downloaded `AGSMobileMapPackage` if possible, setting the kv-observable `hasOfflineMap` boolean property and returning an AGSMap.
     private func loadOfflineMobileMapPackage(_ completion: @escaping (AGSMap?) -> Void) {
         
-        self.mobileMapPackage = LastSyncMobileMapPackage(fileURL: .offlineMapDirectoryURL(forWebMapItemID: AppConfiguration.webMapItemID),
-                                                         userDefaultsKey: "LastSyncMobileMapPackage.\(AppConfiguration.webMapItemID)")
+        self.mobileMapPackage = LastSyncMobileMapPackage(
+            fileURL: .offlineMapDirectoryURL(forWebMapItemID: .webMapItemID),
+            userDefaultsKey: String(format: "LastSyncMobileMapPackage.%@", String.webMapItemID)
+        )
         
         guard let mmpk = self.mobileMapPackage else {
             hasOfflineMap = false
@@ -129,7 +131,10 @@ extension AppContext {
     
     @discardableResult
     func moveDownloadedMapToOfflineMapDirectory() throws -> URL?  {
-        return try FileManager.default.replaceItemAt(.offlineMapDirectoryURL(forWebMapItemID: AppConfiguration.webMapItemID), withItemAt: .temporaryOfflineMapDirectoryURL(forWebMapItemID: AppConfiguration.webMapItemID))
+        return try FileManager.default.replaceItemAt(
+            .offlineMapDirectoryURL(forWebMapItemID: .webMapItemID),
+            withItemAt: .temporaryOfflineMapDirectoryURL(forWebMapItemID: .webMapItemID)
+        )
     }
     
 
@@ -162,8 +167,10 @@ extension AppContext {
     
     /// Open a web map stored in the portal. Set it to the current map and the work mode to online.
     func setWorkModeOnlineWithMapFromPortal() {
-        
-        let portalItem = AGSPortalItem(portal: portal, itemID: AppConfiguration.webMapItemID)
+        let portalItem = AGSPortalItem(
+            portal: portal,
+            itemID: .webMapItemID
+        )
         let map = AGSMap(item: portalItem)
         set(onlineMap: map)
     }

--- a/data-collection/data-collection/App Context/AppContext.swift
+++ b/data-collection/data-collection/App Context/AppContext.swift
@@ -32,7 +32,7 @@ import ArcGIS
     ///
     /// When set, the portal is configured for OAuth authentication so that if login is required,
     /// the Runtime SDK and iOS can work together to authenticate the current user.
-    var portal:AGSPortal = AppConfiguration.buildConfiguredPortal(loginRequired: false) {
+    var portal:AGSPortal = AGSPortal.configuredPortal(loginRequired: false) {
         didSet {
             portal.load { [weak self] (error: Error?) in
                 

--- a/data-collection/data-collection/AppConfiguration.swift
+++ b/data-collection/data-collection/AppConfiguration.swift
@@ -15,20 +15,11 @@
 import UIKit
 import ArcGIS
 
-class AppConfiguration {
-    
-    /// The ID of your portal's [web map](https://runtime.maps.arcgis.com/home/item.html?id=16f1b8ba37b44dc3884afc8d5f454dd2).
-    static let webMapItemID = "16f1b8ba37b44dc3884afc8d5f454dd2"
-    
-    /// The base portal's domain.
-    /// This is used to both build a `URL` to your portal as well as the base URL string used to check reachability.
-    /// - Note: exclude `http` or `https`, this is configured in `basePortalURL`.
-    static let basePortalDomain = "www.arcgis.com"
-    
+extension URL {
     /// The URL to the base portal.
     /// - Note: A `fatalError` is thrown if a URL can't be built from the configuration.
     static let basePortalURL: URL = {
-        guard let url = URL(string: "https://\(basePortalDomain)") else {
+        guard let url = URL(string: "https://\(String.basePortalDomain)") else {
             fatalError("App Configuration must contain a valid portal service url.")
         }
         return url
@@ -43,6 +34,16 @@ class AppConfiguration {
         }
         return url
     }()
+}
+
+extension String {
+    /// The ID of your portal's [web map](https://runtime.maps.arcgis.com/home/item.html?id=16f1b8ba37b44dc3884afc8d5f454dd2).
+    static let webMapItemID = "16f1b8ba37b44dc3884afc8d5f454dd2"
+    
+    /// The base portal's domain.
+    /// This is used to both build a `URL` to your portal as well as the base URL string used to check reachability.
+    /// - Note: exclude `http` or `https`, this is configured in `basePortalURL`.
+    static let basePortalDomain = "www.arcgis.com"
     
     /// The App's URL scheme.
     /// - The URL scheme must match the scheme in the **Current Redirect URIs** section of the **Authentication** tab within the [Dashboard of the ArcGIS for Developers site](https://developers.arcgis.com/applications).
@@ -74,12 +75,12 @@ class AppConfiguration {
 
 // MARK: Portal From Configuration
 
-extension AppConfiguration {
+extension AGSPortal {
     
     /// Build an `AGSPortal` based on the app's configuration.
     /// - Parameter loginRequired: `false` if you intend to access the portal anonymously. `true` if you want to use a credential (the ArcGIS Runtime SDK will present a modal login web view if needed).
     /// - Returns: A new configured `AGSPortal`.
-    static func buildConfiguredPortal(loginRequired: Bool) -> AGSPortal {
-        return AGSPortal(url: basePortalURL, loginRequired: loginRequired)
+    static func configuredPortal(loginRequired: Bool) -> AGSPortal {
+        return AGSPortal(url: .basePortalURL, loginRequired: loginRequired)
     }
 }

--- a/data-collection/data-collection/AppConfiguration.swift
+++ b/data-collection/data-collection/AppConfiguration.swift
@@ -18,7 +18,7 @@ import ArcGIS
 extension URL {
     /// The URL to the base portal.
     /// - Note: A `fatalError` is thrown if a URL can't be built from the configuration.
-    static let basePortalURL: URL = {
+    static let basePortal: URL = {
         guard let url = URL(string: "https://\(String.basePortalDomain)") else {
             fatalError("App Configuration must contain a valid portal service url.")
         }
@@ -28,7 +28,7 @@ extension URL {
     /// The URL to the world geocode service.
     /// Swap out for another geocoder server if you prefer.
     /// - Note: A `fatalError` is thrown if a URL can't be built from the configuration.
-    static let geocodeServiceURL: URL = {
+    static let geocodeService: URL = {
         guard let url = URL(string: "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer") else {
             fatalError("App Configuration must contain a valid geocode service url.")
         }
@@ -45,19 +45,6 @@ extension String {
     /// - Note: exclude `http` or `https`, this is configured in `basePortalURL`.
     static let basePortalDomain = "www.arcgis.com"
     
-    /// The App's URL scheme.
-    /// - The URL scheme must match the scheme in the **Current Redirect URIs** section of the **Authentication** tab within the [Dashboard of the ArcGIS for Developers site](https://developers.arcgis.com/applications).
-    /// - The URL scheme must match the URL scheme in the **URL types** of the Xcode project configuration.
-    static let urlScheme: String = "data-collection"
-    
-    /// The App's URL auth path.
-    /// - The URL scheme must match the path in the **Current Redirect URIs** section of the **Authentication** tab within the Dashboard of the Developers site.
-    static let urlAuthPath: String = "auth"
-    
-    /// The App's full oAuth redirect url path.
-    /// - Note: The path is built using the above configured `urlScheme` and `urlAuthPath`. E.g. `data-collection://auth`.
-    static let oAuthRedirectURLString: String = "\(urlScheme)://\(urlAuthPath)"
-    
     /// Used by the shared `AGSAuthenticationManager` to auto synchronize cached credentials to the device's keychain.
     static let keychainIdentifier: String = "\(appBundleID).keychain"
     
@@ -73,6 +60,20 @@ extension String {
     static let clientID: String = "h3em0ifYNGfz3uHX"
 }
 
+struct OAuth {
+    /// The App's oAuth redirect URL.
+    /// - The URL must match the path created in the **Current Redirect URIs** section of the **Authentication** tab within the [Dashboard of the ArcGIS for Developers site](https://developers.arcgis.com/applications).
+    static let redirectUrl: String = "data-collection://auth"
+    
+    /// The App's full oAuth redirect URL as a `URLComponents` object.
+    static let components: URLComponents = {
+        guard let components = URLComponents(string: redirectUrl) else {
+            fatalError("OAuth.redirectUrl must contain a valid URL.")
+        }
+        return components
+    }()
+}
+
 // MARK: Portal From Configuration
 
 extension AGSPortal {
@@ -81,6 +82,6 @@ extension AGSPortal {
     /// - Parameter loginRequired: `false` if you intend to access the portal anonymously. `true` if you want to use a credential (the ArcGIS Runtime SDK will present a modal login web view if needed).
     /// - Returns: A new configured `AGSPortal`.
     static func configuredPortal(loginRequired: Bool) -> AGSPortal {
-        return AGSPortal(url: .basePortalURL, loginRequired: loginRequired)
+        return AGSPortal(url: .basePortal, loginRequired: loginRequired)
     }
 }

--- a/data-collection/data-collection/AppConfiguration.swift
+++ b/data-collection/data-collection/AppConfiguration.swift
@@ -60,7 +60,7 @@ extension String {
     static let clientID: String = "h3em0ifYNGfz3uHX"
 }
 
-struct OAuth {
+enum OAuth {
     /// The App's oAuth redirect URL.
     /// - The URL must match the path created in the **Current Redirect URIs** section of the **Authentication** tab within the [Dashboard of the ArcGIS for Developers site](https://developers.arcgis.com/applications).
     static let redirectUrl: String = "data-collection://auth"

--- a/data-collection/data-collection/AppDelegate.swift
+++ b/data-collection/data-collection/AppDelegate.swift
@@ -67,15 +67,15 @@ extension AppDelegate {
         //
         // See also AppSettings and AppContext.setupAndLoadPortal() to see how the AGSPortal is configured
         // to handle OAuth and call back to this application.
-        if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
-            urlComponents.scheme == .urlScheme,
-            urlComponents.host == .urlAuthPath {
+        if let redirect = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            redirect.scheme == OAuth.components.scheme,
+            redirect.host == OAuth.components.host {
             
             // Pass the OAuth callback through to the ArcGIS Runtime SDK's helper function.
             AGSApplicationDelegate.shared().application(app, open: url, options: options)
             
             // See if we were called back with confirmation that we're authorized.
-            if urlComponents.hasParameter(named: "code") {
+            if redirect.hasParameter(named: "code") {
                 // If we were authenticated, there should now be a shared credential to use. Let's try it.
                 appContext.signInCurrentPortalIfPossible()
             }
@@ -93,9 +93,9 @@ extension AppDelegate {
     
     static func configOAuthRedirectURL() {
         let oauthConfig = AGSOAuthConfiguration(
-            portalURL: .basePortalURL,
+            portalURL: .basePortal,
             clientID: .clientID,
-            redirectURL: .oAuthRedirectURLString
+            redirectURL: OAuth.redirectUrl
         )
         AGSAuthenticationManager.shared().oAuthConfigurations.add(oauthConfig)
     }

--- a/data-collection/data-collection/AppDelegate.swift
+++ b/data-collection/data-collection/AppDelegate.swift
@@ -67,7 +67,9 @@ extension AppDelegate {
         //
         // See also AppSettings and AppContext.setupAndLoadPortal() to see how the AGSPortal is configured
         // to handle OAuth and call back to this application.
-        if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false), urlComponents.scheme == AppConfiguration.urlScheme, urlComponents.host == AppConfiguration.urlAuthPath {
+        if let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            urlComponents.scheme == .urlScheme,
+            urlComponents.host == .urlAuthPath {
             
             // Pass the OAuth callback through to the ArcGIS Runtime SDK's helper function.
             AGSApplicationDelegate.shared().application(app, open: url, options: options)
@@ -82,15 +84,19 @@ extension AppDelegate {
     }
     
     static func configCredentialCacheAutoSyncToKeychain() {
-        AGSAuthenticationManager.shared().credentialCache.enableAutoSyncToKeychain(withIdentifier: AppConfiguration.keychainIdentifier, accessGroup: nil, acrossDevices: false)
+        AGSAuthenticationManager.shared().credentialCache.enableAutoSyncToKeychain(
+            withIdentifier: .keychainIdentifier,
+            accessGroup: nil,
+            acrossDevices: false
+        )
     }
     
     static func configOAuthRedirectURL() {
-        
-        let oauthConfig = AGSOAuthConfiguration(portalURL: AppConfiguration.basePortalURL,
-                                                clientID: AppConfiguration.clientID,
-                                                redirectURL: AppConfiguration.oAuthRedirectURLString)
-        
+        let oauthConfig = AGSOAuthConfiguration(
+            portalURL: .basePortalURL,
+            clientID: .clientID,
+            redirectURL: .oAuthRedirectURLString
+        )
         AGSAuthenticationManager.shared().oAuthConfigurations.add(oauthConfig)
     }
 }
@@ -103,7 +109,7 @@ extension AppDelegate {
     ///   falling back to Developer Mode (which will display a watermark on the map view).
     static func licenseApplication() {
         do {
-            try AGSArcGISRuntimeEnvironment.setLicenseKey(AppConfiguration.licenseKey)
+            try AGSArcGISRuntimeEnvironment.setLicenseKey(.licenseKey)
         } catch {
             print("[Error: AGSArcGISRuntimeEnvironment] Error licensing app: \(error.localizedDescription)")
         }

--- a/data-collection/data-collection/AppFiles.swift
+++ b/data-collection/data-collection/AppFiles.swift
@@ -20,32 +20,23 @@ class AppFiles {
     
     private var fm: FileManager { return FileManager.default }
     
-    struct OfflineDirectoryComponents {
-        
-        static let dataCollection = "data_collection"
-        static let offlineMap = "offlineMap"
-    }
-    
     /// Build a temporary directory, if needed, to store a map as it downloads.
     ///
     /// - Throws: FileManager errors thrown as a result of building the temporary offline map directory.
     func prepareTemporaryOfflineMapDirectory() throws {
-        
-        let url: URL = .temporaryOfflineMapDirectoryURL(forWebMapItemID: AppConfiguration.webMapItemID)
+        let url: URL = .temporaryOfflineMapDirectoryURL(forWebMapItemID: .webMapItemID)
         try fm.createDirectory(at: url, withIntermediateDirectories: true)
         try fm.removeItem(at: url)
     }
     
     // MARK: Offline Directory    
     func prepareOfflineMapDirectory() throws {
-        
-        let url: URL = .offlineMapDirectoryURL(forWebMapItemID: AppConfiguration.webMapItemID)
+        let url: URL = .offlineMapDirectoryURL(forWebMapItemID: .webMapItemID)
         try fm.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
     }
     
     func deleteContentsOfOfflineMapDirectory() throws {
-        
-        let url: URL = .offlineMapDirectoryURL(forWebMapItemID: AppConfiguration.webMapItemID)
+        let url: URL = .offlineMapDirectoryURL(forWebMapItemID: .webMapItemID)
         try fm.removeItem(at: url)
     }
 }
@@ -60,8 +51,8 @@ extension URL {
     
     static func temporaryOfflineMapDirectoryURL(forWebMapItemID itemID: String) -> URL {
         return URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent(AppFiles.OfflineDirectoryComponents.dataCollection)
-            .appendingPathComponent(AppFiles.OfflineDirectoryComponents.offlineMap)
+            .appendingPathComponent(.dataCollection)
+            .appendingPathComponent(.offlineMap)
             .appendingPathComponent(itemID)
     }
     
@@ -73,8 +64,13 @@ extension URL {
     
     static func offlineMapDirectoryURL(forWebMapItemID itemID: String) -> URL {
         return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent(AppFiles.OfflineDirectoryComponents.dataCollection)
-            .appendingPathComponent(AppFiles.OfflineDirectoryComponents.offlineMap)
+            .appendingPathComponent(.dataCollection)
+            .appendingPathComponent(.offlineMap)
             .appendingPathComponent(itemID)
     }
+}
+
+private extension String {
+    static let dataCollection = "data_collection"
+    static let offlineMap = "offlineMap"
 }

--- a/data-collection/data-collection/AppReachability.swift
+++ b/data-collection/data-collection/AppReachability.swift
@@ -26,7 +26,7 @@ extension NetworkReachabilityManager {
     ///
     /// - SeeAlso: AppContextChangeHandler.swift
     static let shared: NetworkReachabilityManager = {
-        guard let manager = NetworkReachabilityManager(host: AppConfiguration.basePortalDomain) else {
+        guard let manager = NetworkReachabilityManager(host: .basePortalDomain) else {
             fatalError("Network Reachability Manager must be constructed using a valid service url.")
         }
         return manager

--- a/data-collection/data-collection/Geocode Search/AppReverseGeocoderManager.swift
+++ b/data-collection/data-collection/Geocode Search/AppReverseGeocoderManager.swift
@@ -46,7 +46,7 @@ class AppReverseGeocoderManager: AGSLoadableBase {
     }
     
     // Online locator using the world geocoder service.
-    private let onlineLocatorTask = AGSLocatorTask(url: .geocodeServiceURL)
+    private let onlineLocatorTask = AGSLocatorTask(url: .geocodeService)
     
     // Offline locator using the side loaded 'AddressLocator'.
     private let offlineLocatorTask = AGSLocatorTask(name: "AddressLocator")

--- a/data-collection/data-collection/Geocode Search/AppReverseGeocoderManager.swift
+++ b/data-collection/data-collection/Geocode Search/AppReverseGeocoderManager.swift
@@ -46,7 +46,7 @@ class AppReverseGeocoderManager: AGSLoadableBase {
     }
     
     // Online locator using the world geocoder service.
-    private let onlineLocatorTask = AGSLocatorTask(url: AppConfiguration.geocodeServiceURL)
+    private let onlineLocatorTask = AGSLocatorTask(url: .geocodeServiceURL)
     
     // Offline locator using the side loaded 'AddressLocator'.
     private let offlineLocatorTask = AGSLocatorTask(name: "AddressLocator")

--- a/data-collection/data-collection/View Controllers/App Container/AppContainerViewController+MapDelegate.swift
+++ b/data-collection/data-collection/View Controllers/App Container/AppContainerViewController+MapDelegate.swift
@@ -35,7 +35,7 @@ extension AppContainerViewController: MapViewControllerDelegate {
         }
         
         let scale = map.minScale
-        let directory: URL = .temporaryOfflineMapDirectoryURL(forWebMapItemID: AppConfiguration.webMapItemID)
+        let directory: URL = .temporaryOfflineMapDirectoryURL(forWebMapItemID: .webMapItemID)
         let offlineJob = OfflineMapJobConstruct.downloadMapOffline(map, directory, extent, scale)
         
         EphemeralCache.set(object: offlineJob, forKey: OfflineMapJobConstruct.EphemeralCacheKeys.offlineMapJob)


### PR DESCRIPTION
This PR accomplishes a number of tasks for improving the brevity and readability of static configuration tasks.

Swaps `class AppConfiguration` and `AppFiles.OfflineDirectoryComponents` for a series of static `String` and `URL` extensions. This technique allows for brevity through type inference. For example:

```diff
- try AGSArcGISRuntimeEnvironment.setLicenseKey(AppConfiguration.licenseKey)
+ try AGSArcGISRuntimeEnvironment.setLicenseKey(.licenseKey)
```