### PR TITLE
Use credentialCache.removeAndRevokeAllCredentials when signing out.

### DIFF
--- a/data-collection/data-collection/App Context/AppContext+Login.swift
+++ b/data-collection/data-collection/App Context/AppContext+Login.swift
@@ -52,8 +52,16 @@ extension AppContext {
     ///
     /// The app does this by removing all cached credentials and no longer requiring authentication in the portal.
     func signOut() {
-        // We want to remove cached credentials upon sign-out.
-        AGSAuthenticationManager.shared().credentialCache.removeAllCredentials()
+        // We want to remove cached credentials and revoke tokens upon sign-out.
+        AGSAuthenticationManager.shared().credentialCache.removeAndRevokeAllCredentials { (results) in
+            if !results.isEmpty {
+                print("Could not revoke the following credentials:")
+                results.forEach { (credential, error) in
+                    print("  \(credential.username ?? ""); error: \(error.localizedDescription)")
+                }
+            }
+        }
+        
         // We want to remove cached credentials from geo-coder services, in case they are cached.
         appAddressLocator.removeCredentialsFromServices()
         // Setting `loginRequired` to `false` will allow unauthenticated users to consume the map (but not edit!)


### PR DESCRIPTION
Data Collection to support clearing and revoking credential -   As of 100.6, Runtime introduced a method to [clear and revoke credentials](https://developers.arcgis.com/ios/latest/api-reference/interface_a_g_s_credential_cache.html#a0796cf2506fa0edfdeb2b62198bbbea7). This introduction came after the initial general release of Data Collection. Calling this method revokes the portal user's credential on the server side.

Let's retroactively revisit Data Collection to ensure this method is called when a user requests to log out. 

Additional considerations should be made to ensure that services that have been supplied a previously valid credential will issue a challenge again after that credential is revoked.
