### PR TITLE
Increment deployment target from iOS 12 to 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Learn more about Esri open source apps [here](https://developers.arcgis.com/exam
 * [ArcGIS Runtime Toolkit for iOS](https://github.com/Esri/arcgis-runtime-toolkit-ios), version 100.10.
 * To edit records or take a web map offline you will need an ArcGIS Online Organizational account, an ArcGIS Online Developer account or an ArcGIS Online account authenticated using a social login.
 * To consume your own web map you will need an ArcGIS Online Organizational account.
+* Device or Simulator running iOS 13.0 or later.
 
 **Note:** Starting from the 100.8 release, the ArcGIS Runtime SDK for iOS uses Apple's Metal framework to display maps and scenes. However, Xcode does not support Metal based rendering in any version of iOS simulator on macOS Mojave. If you are developing map or scene based apps in these environments, you will need test and debug them on a physical device instead of the simulator.
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Learn more about Esri open source apps [here](https://developers.arcgis.com/exam
 * To edit records or take a web map offline you will need an ArcGIS Online Organizational account, an ArcGIS Online Developer account or an ArcGIS Online account authenticated using a social login.
 * To consume your own web map you will need an ArcGIS Online Organizational account.
 
-**Note:** Starting from the 100.8 release, the ArcGIS Runtime SDK for iOS uses Apple's Metal framework to display maps and scenes. However, Xcode does not support Metal based rendering in iOS 12 simulators on macOS Catalina, or in any version of iOS simulator on macOS Mojave. If you are developing map or scene based apps in these environments, you will need test and debug them on a physical device instead of the simulator.
+**Note:** Starting from the 100.8 release, the ArcGIS Runtime SDK for iOS uses Apple's Metal framework to display maps and scenes. However, Xcode does not support Metal based rendering in any version of iOS simulator on macOS Mojave. If you are developing map or scene based apps in these environments, you will need test and debug them on a physical device instead of the simulator.
 
 **Note:** The 100.10 release of the ArcGIS Runtime SDK for iOS replaces the installed "fat framework" `ArcGIS.framework` with a new binary framework `ArcGIS.xcframework`.  It also changes the location of the installed framework file and removes the need for the `strip-frameworks.sh` Build Phase.  These changes have been incorporated in the lastest release of the *Data Collection app*.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
     - The Build Phase which ran the `strip-frameworks.sh` shell script is no longer necessary.
 - Certification for the 100.10 release of the ArcGIS Runtime SDK for iOS.
 - Updates the ArcGIS Runtime Toolkit submodule to the 100.10 version.
+- Increments app and testing deployment targets to iOS 13.0, drops support for iOS 12.0.
 
 # Release 1.2.2
 

--- a/data-collection/data-collection.xcodeproj/project.pbxproj
+++ b/data-collection/data-collection.xcodeproj/project.pbxproj
@@ -1776,6 +1776,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "data-collectionTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1796,6 +1797,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "data-collectionTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1815,6 +1817,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "data-collectionUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1834,6 +1837,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "data-collectionUITests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/data-collection/data-collection.xcodeproj/project.pbxproj
+++ b/data-collection/data-collection.xcodeproj/project.pbxproj
@@ -1728,6 +1728,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1752,6 +1753,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 23PX5GD8E6;
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/data-collection/data-collection/App Context/AppContextAwareNavigationController.swift
+++ b/data-collection/data-collection/App Context/AppContextAwareNavigationController.swift
@@ -43,19 +43,14 @@ class AppContextAwareNavigationController: UINavigationController {
     @objc
     func adjustNavigationBarTintForWorkMode() {
         
-        if #available(iOS 13.0, *) {
-            let navBarAppearance = UINavigationBarAppearance()
-            navBarAppearance.configureWithOpaqueBackground()
-            navBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.contrasting]
-            navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.contrasting]
-            navBarAppearance.backgroundColor = appContext.workMode == .online ? .primary : .offline
-            navigationBar.standardAppearance = navBarAppearance
-            navigationBar.scrollEdgeAppearance = navBarAppearance
-            navigationBar.compactAppearance = navBarAppearance
-        }
-        else {
-            navigationBar.barTintColor = appContext.workMode == .online ? .primary : .offline
-        }
+        let navBarAppearance = UINavigationBarAppearance()
+        navBarAppearance.configureWithOpaqueBackground()
+        navBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.contrasting]
+        navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.contrasting]
+        navBarAppearance.backgroundColor = appContext.workMode == .online ? .primary : .offline
+        navigationBar.standardAppearance = navBarAppearance
+        navigationBar.scrollEdgeAppearance = navBarAppearance
+        navigationBar.compactAppearance = navBarAppearance
         
         // Hiding then un-hiding the navigation bar appears to force a redraw.
         // This fixes an issue with iOS 13 where the background color doesn't update.

--- a/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
+++ b/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
@@ -174,16 +174,7 @@ public struct ImagePickerPermissions {
         
         let viewController = delegate.imagePickerPermissionsRequestsPresentingViewController()
         
-        let style: UIAlertController.Style
-        if #available(iOS 13.0, *) {
-            // In iOS 12.x, this used to crash without using `.alert` or setting either
-            // a UIBarButtonItem or sourceView and rect.  Fixed in iOS 13.
-            style = .actionSheet
-        }
-        else {
-            style = .alert
-        }
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: style)
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
         for permission in permissions {
             

--- a/data-collection/data-collection/View Controllers/Profile View Controller/ProfileViewController.swift
+++ b/data-collection/data-collection/View Controllers/Profile View Controller/ProfileViewController.swift
@@ -422,21 +422,11 @@ protocol Dimmable {
 extension Dimmable {
     
     func dim() {
-        if #available(iOS 13.0, *) {
-            dimmableLabel.textColor = .secondaryLabel
-        }
-        else {
-            dimmableLabel.textColor = .gray
-        }
+        dimmableLabel.textColor = .secondaryLabel
     }
     
     func brighten() {
-        if #available(iOS 13.0, *) {
-            dimmableLabel.textColor = .label
-        }
-        else {
-            dimmableLabel.textColor = .black
-        }
+        dimmableLabel.textColor = .label
     }
 }
 
@@ -456,17 +446,10 @@ class WorkModeCell: UITableViewCell, Dimmable {
             icon.tintColor = .contrasting
         }
         else {
-            if #available(iOS 13.0, *) {
-                backgroundColor = .secondarySystemGroupedBackground
-                titleLabel.textColor = .label
-                subtitleLabel.textColor = .secondaryLabel
-                icon.tintColor = .primary
-            } else {
-                backgroundColor = .white
-                titleLabel.textColor = .black
-                subtitleLabel.textColor = .darkGray
-                icon.tintColor = .primary
-            }
+            backgroundColor = .secondarySystemGroupedBackground
+            titleLabel.textColor = .label
+            subtitleLabel.textColor = .secondaryLabel
+            icon.tintColor = .primary
         }
     }
 }

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupDetailsViewController/RichPopupDetailsViewController+UITableViewDataSource.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupDetailsViewController/RichPopupDetailsViewController+UITableViewDataSource.swift
@@ -219,7 +219,7 @@ extension RichPopupDetailsViewController /* UITableViewDataSource */ {
         let container = UIView(frame: CGRect(x: 0.0, y: 0.0, width: tableView.frame.width, height: activityIndicatorViewHeight))
         container.backgroundColor = .clear
         
-        let activity = UIActivityIndicatorView(style: .gray)
+        let activity = UIActivityIndicatorView(style: .medium)
         activity.accessibilityLabel = "Loading Related Records"
         activity.startAnimating()
         

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController.swift
@@ -178,11 +178,8 @@ class RichPopupViewController: SegmentedViewController {
             self.navigationItem.leftBarButtonItem = self.dismissButton
         }
         
-        // Because iOS 13 introduces a new modal dismissal paradigm (swipe-down),
-        // we need to inform the view controller not to dismiss the view controller if editing.
-        if #available(iOS 13.0, *) {
-            isModalInPresentation = self.popupManager.isEditing
-        }
+        // Inform the view controller not to dismiss the view controller if editing.
+        isModalInPresentation = self.popupManager.isEditing
         
         // If this is a newly added record, we will need to add a delete button.
         conditionallyAddDeleteButton()


### PR DESCRIPTION
This PR drops support for iOS 12, removes properties deprecated by iOS 13, and increments the deployment target to iOS 13.
[[Related Issue]](https://github.com/ArcGIS/open-source-apps/issues/458)