### PR TITLE
Introduces Package.resolved file

### DIFF
--- a/data-collection/data-collection.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/data-collection/data-collection.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Alamofire",
+        "repositoryURL": "https://github.com/Alamofire/Alamofire",
+        "state": {
+          "branch": null,
+          "revision": "9e0328127dfb801cefe8ac53a13c0c90a7770448",
+          "version": "5.4.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
Alamofire will is removed in the `v.next-1.3` release branch. However for now, Alamofire remains an active dependency. As such, we should commit the `Package.resolved` file to vc.