### PR TITLE
Enhanced support for pop-up date attribute editing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,8 @@
 - Certification for the 100.10 release of the ArcGIS Runtime SDK for iOS.
 - Updates the ArcGIS Runtime Toolkit submodule to the 100.10 version.
 - Increments app and testing deployment targets to iOS 13.0, drops support for iOS 12.0.
+- Introduces pop-up date attribute editing support for the new iOS 14 `UIDatePicker`.
+- Introduces pop-up date attribute editing support for time as well as date.
 - Fixes bug where `SegmentedViewController` does not respond to `segmentedControl`'s `.valueChanged` event.
 
 # Release 1.2.2

--- a/data-collection/data-collection.xcodeproj/project.pbxproj
+++ b/data-collection/data-collection.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		946D20BE2130965A001BF5CC /* MapViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 946D20BD2130965A001BF5CC /* MapViewController.storyboard */; };
 		946D20C22130C236001BF5CC /* LastSyncMobileMapPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946D20C12130C236001BF5CC /* LastSyncMobileMapPackage.swift */; };
 		946E6A9521F2A96000B315B6 /* RichPopupViewController+EditingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946E6A9421F2A96000B315B6 /* RichPopupViewController+EditingSession.swift */; };
+		947AC8C9256EF25F00C30598 /* PopupAttributeDatePickerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947AC8C8256EF25F00C30598 /* PopupAttributeDatePickerCell.swift */; };
 		948066332091474F00A398EA /* RichPopup.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 948066322091474F00A398EA /* RichPopup.storyboard */; };
 		948066382091595200A398EA /* RichPopupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 948066372091595200A398EA /* RichPopupManager.swift */; };
 		9487942321F7CD47007BC15E /* StyledFirstResponderLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9487942221F7CD47007BC15E /* StyledFirstResponderLabel.swift */; };
@@ -331,6 +332,7 @@
 		946D20BD2130965A001BF5CC /* MapViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MapViewController.storyboard; sourceTree = "<group>"; };
 		946D20C12130C236001BF5CC /* LastSyncMobileMapPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastSyncMobileMapPackage.swift; sourceTree = "<group>"; };
 		946E6A9421F2A96000B315B6 /* RichPopupViewController+EditingSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RichPopupViewController+EditingSession.swift"; sourceTree = "<group>"; };
+		947AC8C8256EF25F00C30598 /* PopupAttributeDatePickerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupAttributeDatePickerCell.swift; sourceTree = "<group>"; };
 		948066322091474F00A398EA /* RichPopup.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RichPopup.storyboard; sourceTree = "<group>"; };
 		948066372091595200A398EA /* RichPopupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichPopupManager.swift; sourceTree = "<group>"; };
 		9487942221F7CD47007BC15E /* StyledFirstResponderLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StyledFirstResponderLabel.swift; sourceTree = "<group>"; };
@@ -665,6 +667,7 @@
 				9487942421F8F524007BC15E /* PopupAttributeDomainCell.swift */,
 				945F454221E7D1CF00F2DCBC /* PopupAttributeTextViewCell.swift */,
 				945F454021E7D11D00F2DCBC /* PopupAttributeDateCell.swift */,
+				947AC8C8256EF25F00C30598 /* PopupAttributeDatePickerCell.swift */,
 				948794542204F198007BC15E /* PopupAttributeReadonlyCell.swift */,
 			);
 			path = "Attribute Cells";
@@ -1392,6 +1395,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				944D0CC424E1DE4800EE49CB /* AppSecrets.swift.masque in Sources */,
+				947AC8C9256EF25F00C30598 /* PopupAttributeDatePickerCell.swift in Sources */,
 				945F455421E96DC000F2DCBC /* AGSPopupAttachmentType+Icon.swift in Sources */,
 				948066382091595200A398EA /* RichPopupManager.swift in Sources */,
 				945F456221F00AD200F2DCBC /* AGSPopupAttachment+AppAttachment.swift in Sources */,

--- a/data-collection/data-collection/AppColors.swift
+++ b/data-collection/data-collection/AppColors.swift
@@ -64,5 +64,7 @@ extension AppDelegate {
         UISegmentedControl.appearance().tintColor = .primary
         
         StyledFirstResponderLabel.appearance().tintColor = .primary
+        
+        UIDatePicker.appearance().tintColor = .primary
     }
 }

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupDetailsViewController/RichPopupDetailsViewController+UITableViewDataSource.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupDetailsViewController/RichPopupDetailsViewController+UITableViewDataSource.swift
@@ -113,7 +113,18 @@ extension RichPopupDetailsViewController /* UITableViewDataSource */ {
                     cell = textFieldCell
                     
                 case (.date, _):
-                    cell = tableView.dequeueReusableCell(withIdentifier: "PopupAttributeDateCell", for: indexPath) as! PopupAttributeDateCell
+                    if #available(iOS 14, *) {
+                        cell = tableView.dequeueReusableCell(
+                            withIdentifier: "PopupAttributeDatePickerCell",
+                            for: indexPath
+                        ) as! PopupAttributeDatePickerCell
+                    }
+                    else {
+                        cell = tableView.dequeueReusableCell(
+                            withIdentifier: "PopupAttributeDateCell",
+                            for: indexPath
+                        ) as! PopupAttributeDateCell
+                    }
                     
                 case (.GUID, _), (.OID, _), (.globalID, _), (.unknown, _):
                     cell = tableView.dequeueReusableCell(withIdentifier: "PopupAttributeReadonlyCell", for: indexPath) as! PopupAttributeReadonlyCell

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupDetailsViewController/Table Cells/Attribute Cells/PopupAttributeDateCell.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupDetailsViewController/Table Cells/Attribute Cells/PopupAttributeDateCell.swift
@@ -81,7 +81,7 @@ extension PopupAttributeDateCell: StyledFirstResponderLabelDelegate {
     func inputViewForStyledFirstResponderLabel(_ label: StyledFirstResponderLabel) -> UIView? {
         
         let datePickerView = UIDatePicker()
-        datePickerView.datePickerMode = .date
+        datePickerView.datePickerMode = .dateAndTime
         datePickerView.addTarget(self, action: #selector(PopupAttributeDateCell.datePickerValueChanged(sender:)), for: .valueChanged)
         
         datePickerView.reloadInputViews()

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupDetailsViewController/Table Cells/Attribute Cells/PopupAttributeDatePickerCell.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupDetailsViewController/Table Cells/Attribute Cells/PopupAttributeDatePickerCell.swift
@@ -1,0 +1,94 @@
+// Copyright 2020 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+class PopupAttributeDatePickerCell: UITableViewCell {
+
+    @IBOutlet weak var attributeTitleLabel: UILabel!
+    // Label for viewing attribute date value
+    @IBOutlet weak var attributeValueLabel: UILabel!
+    // Date picker for editing attribute date value
+    @IBOutlet weak var datePicker: UIDatePicker!
+    
+    var indexPath = IndexPath(row: 0, section: 0)
+    var delegate: PopupAttributeCellDelegate?
+    
+    private var title: String = ""
+    private var value: AttributeValue = ("", nil)
+    
+    override func setEditing(_ editing: Bool, animated: Bool) {
+        super.setEditing(editing, animated: animated)
+        if editing {
+            datePicker.isHidden = false
+            attributeValueLabel.isHidden = true
+        }
+        else {
+            datePicker.isHidden = true
+            attributeValueLabel.isHidden = false
+        }
+    }
+}
+
+extension PopupAttributeDatePickerCell: PopupAttributeCell {
+    
+    func setTitle(_ title: String, value: AttributeValue) {
+        
+        // Title
+        self.title = title
+        attributeTitleLabel.text = self.title
+        
+        // Value
+        self.value = value
+        attributeValueLabel.text = self.value.formatted
+        if let date = self.value.raw as? Date {
+            datePicker.date = date
+        }
+        
+        attributeTitleLabel.considerEmptyString()
+        attributeValueLabel.considerEmptyString()
+        
+    }
+    
+    func setValidity(_ error: Error?) {
+        
+        if let error = error {
+            attributeTitleLabel.text = String(format: "%@: %@", self.title, error.localizedDescription)
+            attributeTitleLabel.textColor = .destructive
+        }
+        else {
+            attributeTitleLabel.text = self.title
+            attributeTitleLabel.textColor = .lightGray
+        }
+        
+        attributeTitleLabel.considerEmptyString()
+        attributeValueLabel.considerEmptyString()
+    }
+    
+    // This value is nil because the iOS 14 UIDatePicker is not displayed in the keyboard area,
+    // iOS manages the responder chain for this UI element independently.
+    var firstResponder: UIView? {
+        nil
+    }
+}
+
+extension PopupAttributeDatePickerCell {
+    
+    @IBAction func pickerValueDidChange(_ sender: UIDatePicker) {
+        if let formatted = delegate?.popupAttributeCell(self, valueDidChange: sender.date, at: indexPath) {
+            self.value = (formatted, sender.date)
+            self.attributeValueLabel.text = formatted
+        }
+    }
+}

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupDetailsViewController/Table Cells/Attribute Cells/PopupAttributeDatePickerCell.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupDetailsViewController/Table Cells/Attribute Cells/PopupAttributeDatePickerCell.swift
@@ -30,14 +30,8 @@ class PopupAttributeDatePickerCell: UITableViewCell {
     
     override func setEditing(_ editing: Bool, animated: Bool) {
         super.setEditing(editing, animated: animated)
-        if editing {
-            datePicker.isHidden = false
-            attributeValueLabel.isHidden = true
-        }
-        else {
-            datePicker.isHidden = true
-            attributeValueLabel.isHidden = false
-        }
+        datePicker.isHidden = !editing
+        attributeValueLabel.isHidden = editing
     }
 }
 

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/RichPopup.storyboard
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/RichPopup.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zWV-AL-ABc">
-    <device id="retina5_9" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zWV-AL-ABc">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,8 +16,8 @@
                     <view key="view" contentMode="scaleToFill" id="DWL-hJ-ASW">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <viewLayoutGuide key="safeArea" id="1Yb-Qs-yZR"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
                     <navigationItem key="navigationItem" title="Popup" id="cZ5-CT-XPL"/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
@@ -41,27 +39,26 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" allowsSelectionDuringEditing="YES" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="rbN-9M-Ecb">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PopupAttributeTextFieldCell" rowHeight="94" id="dUj-ga-dbu" customClass="PopupAttributeTextFieldCell" customModule="data_collection" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.333333333333343" width="375" height="94"/>
+                                <rect key="frame" x="0.0" y="55.333332061767578" width="375" height="94"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dUj-ga-dbu" id="hpL-gE-DOt">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="93.666666666666671"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="94"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="OZe-QL-Yv2">
                                             <rect key="frame" x="16" y="19" width="343" height="56"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Attribute Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wJA-QV-ToO">
-                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="17"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="15.666666666666666"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Attribute Value" borderStyle="roundedRect" textAlignment="natural" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ufm-PF-SJE" customClass="StyledTextField" customModule="data_collection" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="23" width="343" height="33"/>
-                                                    <nil key="textColor"/>
+                                                    <rect key="frame" x="0.0" y="21.666666666666661" width="343" height="34.333333333333343"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
@@ -81,23 +78,23 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PopupAttributeDateCell" rowHeight="94" id="ktN-Xj-BWP" customClass="PopupAttributeDateCell" customModule="data_collection" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="149.33333333333334" width="375" height="94"/>
+                                <rect key="frame" x="0.0" y="149.33333206176758" width="375" height="94"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ktN-Xj-BWP" id="OZK-f9-Taq">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="93.666666666666671"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="94"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="3Pp-Mq-v29">
                                             <rect key="frame" x="16" y="19" width="343" height="56"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Date Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zzi-uL-6cL">
-                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="21"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="17"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Date Value" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xeO-Rr-RCV" customClass="StyledFirstResponderLabel" customModule="data_collection" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="27" width="343" height="29"/>
+                                                <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Date Value" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xeO-Rr-RCV" customClass="StyledFirstResponderLabel" customModule="data_collection" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="23" width="343" height="33"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -117,24 +114,73 @@
                                     <outlet property="attributeValueLabel" destination="xeO-Rr-RCV" id="eOu-Oc-lqz"/>
                                 </connections>
                             </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PopupAttributeDatePickerCell" rowHeight="94" id="H7q-qI-yLx" customClass="PopupAttributeDatePickerCell" customModule="data_collection" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="243.33333206176758" width="375" height="94"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="H7q-qI-yLx" id="uXr-h6-QOf">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="94"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="nbO-0h-K5e">
+                                            <rect key="frame" x="16" y="19" width="343" height="56"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Date Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ABt-tD-yYa">
+                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="15.666666666666666"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="V8b-qH-tw3">
+                                                    <rect key="frame" x="0.0" y="21.666666666666661" width="343" height="34.333333333333343"/>
+                                                    <subviews>
+                                                        <datePicker contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="30" translatesAutoresizingMaskIntoConstraints="NO" id="F05-ep-j1G">
+                                                            <rect key="frame" x="0.0" y="0.0" width="293" height="34.333333333333336"/>
+                                                            <connections>
+                                                                <action selector="pickerValueDidChange:" destination="H7q-qI-yLx" eventType="valueChanged" id="nK6-9H-7AU"/>
+                                                            </connections>
+                                                        </datePicker>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TIn-Qv-oPh">
+                                                            <rect key="frame" x="293" y="0.0" width="50" height="34.333333333333336"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                        </stackView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="nbO-0h-K5e" firstAttribute="leading" secondItem="uXr-h6-QOf" secondAttribute="leadingMargin" id="2vp-SV-IKi"/>
+                                        <constraint firstItem="nbO-0h-K5e" firstAttribute="bottom" secondItem="uXr-h6-QOf" secondAttribute="bottomMargin" priority="999" constant="-8" id="6zP-cG-7dl"/>
+                                        <constraint firstItem="nbO-0h-K5e" firstAttribute="top" secondItem="uXr-h6-QOf" secondAttribute="topMargin" priority="999" constant="8" id="edr-vH-kwk"/>
+                                        <constraint firstItem="nbO-0h-K5e" firstAttribute="trailing" secondItem="uXr-h6-QOf" secondAttribute="trailingMargin" id="gQH-Ng-Oi2"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="attributeTitleLabel" destination="ABt-tD-yYa" id="K0z-ea-hsG"/>
+                                    <outlet property="attributeValueLabel" destination="TIn-Qv-oPh" id="zmT-7C-Y3O"/>
+                                    <outlet property="datePicker" destination="F05-ep-j1G" id="PuI-Bt-rhh"/>
+                                </connections>
+                            </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PopupAttributeDomainCell" rowHeight="94" id="cuS-GZ-9oX" customClass="PopupAttributeDomainCell" customModule="data_collection" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="243.33333333333337" width="375" height="94"/>
+                                <rect key="frame" x="0.0" y="337.33333206176758" width="375" height="94"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cuS-GZ-9oX" id="wAK-Ke-6Dk">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="93.666666666666671"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="94"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="g6G-KJ-kyA">
                                             <rect key="frame" x="16" y="19" width="343" height="56"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Domain Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nWc-dP-hOS">
-                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="21"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="17"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Domain Value" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rvg-2r-SkT" customClass="StyledFirstResponderLabel" customModule="data_collection" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="27" width="343" height="29"/>
+                                                    <rect key="frame" x="0.0" y="23" width="343" height="33"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -155,10 +201,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PopupAttributeTextViewCell" rowHeight="159.99999999999997" id="flH-9F-Kjw" customClass="PopupAttributeTextViewCell" customModule="data_collection" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="337.33333333333337" width="375" height="160"/>
+                                <rect key="frame" x="0.0" y="431.33333206176758" width="375" height="160"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="flH-9F-Kjw" id="5s8-Pn-vAf">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="159.66666666666666"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="160"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="wf5-dY-MkR">
@@ -195,10 +241,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PopupAttributeReadonlyCell" rowHeight="94" id="xjX-04-SCJ" customClass="PopupAttributeReadonlyCell" customModule="data_collection" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="497.33333333333337" width="375" height="94"/>
+                                <rect key="frame" x="0.0" y="591.33333206176758" width="375" height="94"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xjX-04-SCJ" id="RWS-km-lBD">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="93.666666666666671"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="94"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="L09-fO-ezl">
@@ -232,10 +278,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PopupNewOneToManyRecordCell" rowHeight="54" id="Ul5-hw-ZyM" customClass="PopupNewRelatedRecordCell" customModule="data_collection" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="591.33333333333337" width="375" height="54"/>
+                                <rect key="frame" x="0.0" y="685.33333206176758" width="375" height="54"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ul5-hw-ZyM" id="Lu5-Jr-anz">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="53.666666666666664"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d2T-fr-aZa">
@@ -268,14 +314,14 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="PopupRelatedRecordCell" editingAccessoryType="disclosureIndicator" rowHeight="79" id="cIN-Sy-cNx" customClass="PopupRelatedRecordCell" customModule="data_collection" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="645.33333333333337" width="375" height="79"/>
+                                <rect key="frame" x="0.0" y="739.33333206176758" width="375" height="79"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cIN-Sy-cNx" id="ryV-pL-yyY">
-                                    <rect key="frame" x="0.0" y="0.0" width="341" height="78.666666666666671"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="347.66666666666669" height="79"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="uVn-2Y-88d">
-                                            <rect key="frame" x="16" y="19" width="317" height="41"/>
+                                            <rect key="frame" x="16" y="19" width="323.66666666666669" height="41"/>
                                         </stackView>
                                     </subviews>
                                     <constraints>
@@ -309,13 +355,13 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="jmd-Kd-eZ1">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="PopupSelectRelatedRecordCell" rowHeight="91" id="SZl-Xp-4iS" customClass="PopupSelectRelatedRecordCell" customModule="data_collection" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.333333333333343" width="375" height="91"/>
+                                <rect key="frame" x="0.0" y="55.333332061767578" width="375" height="91"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="SZl-Xp-4iS" id="vPg-Qa-UzM">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="90.666666666666671"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="91"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="thT-R6-lGO">
@@ -352,13 +398,13 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" allowsSelectionDuringEditing="YES" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="F0g-Gw-aJO">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PopupAddAttachmentCell" rowHeight="54" id="SVL-Vw-kHI" customClass="PopupAddAttachmentCell" customModule="data_collection" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.333333333333343" width="375" height="54"/>
+                                <rect key="frame" x="0.0" y="55.333332061767578" width="375" height="54"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="SVL-Vw-kHI" id="cO2-9v-tQU">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="53.666666666666664"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fgm-uS-iDo">
@@ -388,10 +434,10 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PopupAttachmentCell" rowHeight="72" id="UjP-J8-FCZ" customClass="PopupAttachmentCell" customModule="data_collection" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="109.33333333333334" width="375" height="72"/>
+                                <rect key="frame" x="0.0" y="109.33333206176758" width="375" height="72"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UjP-J8-FCZ" id="rIW-Rz-GNX">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="71.666666666666671"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="72"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="KHr-md-Nwr">
@@ -475,15 +521,15 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="HgQ-W6-yae">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Name" id="XHS-do-haw">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="54" id="PnV-J4-WYK">
-                                        <rect key="frame" x="0.0" y="55.333333333333343" width="375" height="54"/>
+                                        <rect key="frame" x="0.0" y="55.333332061767578" width="375" height="54"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PnV-J4-WYK" id="ibV-Sr-SUp">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="53.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QHe-vg-qbw">
@@ -491,7 +537,6 @@
                                                     <subviews>
                                                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Photo 1" placeholder="Name" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="VT8-vh-klL">
                                                             <rect key="frame" x="0.0" y="0.0" width="343" height="32"/>
-                                                            <nil key="textColor"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                             <connections>
@@ -515,14 +560,14 @@
                             <tableViewSection headerTitle="Preferred Size" footerTitle="The preferred size is scaled to the device's screen size and will upload an image no larger than the size selected." id="pi6-9f-7CR">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="FJs-Yj-FFK" rowHeight="48" style="IBUITableViewCellStyleDefault" id="gMB-J2-Axi">
-                                        <rect key="frame" x="0.0" y="172.66666666666669" width="375" height="48"/>
+                                        <rect key="frame" x="0.0" y="172.66666412353516" width="375" height="48"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gMB-J2-Axi" id="ItQ-ai-jvF">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="47.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Small (240x320)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="FJs-Yj-FFK">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="47.666666666666664"/>
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="48"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
@@ -532,14 +577,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="fD8-3Q-cuL" rowHeight="48" style="IBUITableViewCellStyleDefault" id="gjz-QH-lY9">
-                                        <rect key="frame" x="0.0" y="220.66666666666669" width="375" height="48"/>
+                                        <rect key="frame" x="0.0" y="220.66666412353516" width="375" height="48"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gjz-QH-lY9" id="vDz-kR-nYg">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="47.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Medium (480x640)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="fD8-3Q-cuL">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="47.666666666666664"/>
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="48"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
@@ -549,14 +594,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="S98-uL-7r3" rowHeight="48" style="IBUITableViewCellStyleDefault" id="Yiz-Y0-iaI">
-                                        <rect key="frame" x="0.0" y="268.66666666666669" width="375" height="48"/>
+                                        <rect key="frame" x="0.0" y="268.66666412353516" width="375" height="48"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Yiz-Y0-iaI" id="eL1-WF-QLN">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="47.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Large (960x1280)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="S98-uL-7r3">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="47.666666666666664"/>
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="48"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
@@ -566,14 +611,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="wfV-bk-e2V" rowHeight="48" style="IBUITableViewCellStyleDefault" id="ft9-UI-zuv">
-                                        <rect key="frame" x="0.0" y="316.66666666666669" width="375" height="48"/>
+                                        <rect key="frame" x="0.0" y="316.66666412353516" width="375" height="48"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ft9-UI-zuv" id="xaC-ut-gDm">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="47.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Extra Large (1126x1500)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="wfV-bk-e2V">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="47.666666666666664"/>
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="48"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
@@ -583,14 +628,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Jwt-Zw-Rtg" rowHeight="48" style="IBUITableViewCellStyleDefault" id="gQR-En-8Fg">
-                                        <rect key="frame" x="0.0" y="364.66666666666669" width="375" height="48"/>
+                                        <rect key="frame" x="0.0" y="364.66666412353516" width="375" height="48"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gQR-En-8Fg" id="9AM-Zl-3H3">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="47.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Actual Size" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="Jwt-Zw-Rtg">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="47.666666666666664"/>
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="48"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
@@ -634,9 +679,29 @@
             <point key="canvasLocation" x="694" y="-669"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="rvg-2r-SkT">
+            <size key="intrinsicContentSize" width="118.33333333333333" height="30.333333333333332"/>
+        </designable>
+        <designable name="xeO-Rr-RCV">
+            <size key="intrinsicContentSize" width="96" height="30.333333333333332"/>
+        </designable>
+    </designables>
     <resources>
         <namedColor name="primary">
             <color red="0.37999999523162842" green="0.60000002384185791" blue="0.23999999463558197" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
This PR introduces enhanced support for pop-up date attribute editing.

1. Introduces new table cell, `PopupAttributeDatePickerCell`, for use by devices running iOS 14. This cell leverages the new iOS 14 `UIDatePicker`, placing the UI element within the attribute cell rather than displaying a date picker in the keyboard area.
1. Introduces support for _time_ as well as date (iOS 13 & 14)

See related issues:
- [[Support for iOS 14]](https://github.com/ArcGIS/open-source-apps/issues/468)
- [[Editing popup date fields to support date and time]](https://github.com/ArcGIS/open-source-apps/issues/472)

### Screenshots

| iOS 13 | iOS 14 - in-line | iOS 14 - expanded |
| --- | --- | --- |
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-25 at 14 03 20](https://user-images.githubusercontent.com/33433113/100286941-99c5b380-2f28-11eb-902b-50152eda92c9.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-25 at 14 16 24](https://user-images.githubusercontent.com/33433113/100287083-ddb8b880-2f28-11eb-8a35-74f1dcf8a7d1.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-25 at 14 16 27](https://user-images.githubusercontent.com/33433113/100287101-e610f380-2f28-11eb-970a-0929d4c51228.png) |

| Dark Mode | Dynamic Text Size | 
| --- | --- | 
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-25 at 14 00 50](https://user-images.githubusercontent.com/33433113/100287168-09d43980-2f29-11eb-964a-1902026a398b.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-25 at 14 01 05](https://user-images.githubusercontent.com/33433113/100287194-122c7480-2f29-11eb-96fb-c9377f01ff3b.png) |

| iPad - in-line | iPad - expanded |
| --- | --- |
| ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-11-25 at 14 02 33](https://user-images.githubusercontent.com/33433113/100287249-2c665280-2f29-11eb-8048-7863c78632b0.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-11-25 at 14 02 37](https://user-images.githubusercontent.com/33433113/100287279-34be8d80-2f29-11eb-8e14-2b432cef5418.png) |
