### PR TITLE
Segmented control bug

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@
 - Certification for the 100.10 release of the ArcGIS Runtime SDK for iOS.
 - Updates the ArcGIS Runtime Toolkit submodule to the 100.10 version.
 - Increments app and testing deployment targets to iOS 13.0, drops support for iOS 12.0.
-- Fixes bug where SegmentedViewController does not respond to segmentedControl's valueChanged event.
+- Fixes bug where `SegmentedViewController` does not respond to `segmentedControl`'s `.valueChanged` event.
 
 # Release 1.2.2
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 - Certification for the 100.10 release of the ArcGIS Runtime SDK for iOS.
 - Updates the ArcGIS Runtime Toolkit submodule to the 100.10 version.
 - Increments app and testing deployment targets to iOS 13.0, drops support for iOS 12.0.
+- Fixes bug where SegmentedViewController does not respond to segmentedControl's valueChanged event.
 
 # Release 1.2.2
 

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/SegmentedViewController.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/SegmentedViewController.swift
@@ -46,7 +46,7 @@ class SegmentedViewController: UIViewController {
         return visualEffectView
     }()
     
-    let segmentedControl: UISegmentedControl = {
+    lazy var segmentedControl: UISegmentedControl = {
         let segmentedControl = UISegmentedControl()
         segmentedControl.translatesAutoresizingMaskIntoConstraints = false
         segmentedControl.addTarget(self, action: #selector(segmentedControlValueDidChange(_:)), for: .valueChanged)


### PR DESCRIPTION
Fixes bug where added target does not perform selector when `.valueChanged` event occurs. This PR lazily initializes `segmentedControl`, guaranteeing `self` is fully initialized before adding the target.