### PR TITLE
Mhd/photo library permissions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@
 - Introduces pop-up date attribute editing support for the new iOS 14 `UIDatePicker`.
 - Introduces pop-up date attribute editing support for time as well as date.
 - Fixes bug where `SegmentedViewController` does not respond to `segmentedControl`'s `.valueChanged` event.
-- On iOS 14, when adding image attachments to features using the user's "Photo Library", the "Selected Photos" privacy option is not supported yet.  The user will need to grant the app permission to use "All Photos".
+- On iOS 14, when adding image attachments to features using the user's "Photo Library", the "Selected Photos" privacy option is not yet supported.  The user will need to grant the app permission to use "All Photos".
 
 # Release 1.2.2
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 - Introduces pop-up date attribute editing support for the new iOS 14 `UIDatePicker`.
 - Introduces pop-up date attribute editing support for time as well as date.
 - Fixes bug where `SegmentedViewController` does not respond to `segmentedControl`'s `.valueChanged` event.
+- On iOS 14, when adding image attachments to features using the user's "Photo Library", the "Selected Photos" privacy option is not supported yet.  The user will need to grant the app permission to use "All Photos".
 
 # Release 1.2.2
 

--- a/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
+++ b/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
@@ -287,9 +287,14 @@ extension ImagePickerPermissions {
         var actionTitle: String {
             return "Image Library"
         }
-        
+
         func isAuthorized() -> Bool {
-            return PHPhotoLibrary.authorizationStatus() == .authorized
+            if #available(iOS 14, *) {
+                return PHPhotoLibrary.authorizationStatus(for: .readWrite) == .authorized
+            }
+            else {
+                return PHPhotoLibrary.authorizationStatus() == .authorized
+            }
         }
         
         func shouldRequest() -> Bool {


### PR DESCRIPTION
Adds a check to not allow the PHAuthorizationStatus.limited status.  This will change once we move away from `UIImagePickerViewController` to the new `PHPickerViewController`.

Also added a release note describing it.