### PR TITLE
Post Pop-up Editing Bug

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 - Introduces pop-up date attribute editing support for the new iOS 14 `UIDatePicker`.
 - Introduces pop-up date attribute editing support for time as well as date.
 - Fixes bug where `SegmentedViewController` does not respond to `segmentedControl`'s `.valueChanged` event.
+- Fixes bug where `MapViewController` does not update current pop-up after edits are performed.
 
 # Release 1.2.2
 

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController.swift
@@ -15,6 +15,8 @@
 import UIKit
 import ArcGIS
 import ArcGISToolkit
+import Combine
+
 
 class MapViewController: UIViewController {
     
@@ -122,12 +124,6 @@ class MapViewController: UIViewController {
         // If device is not reachable upon launch, inform the end-user.
         displayInitialReachabilityMessage()
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        refreshCurrentPopup()
-    }
         
     // MARK:- Extras
     
@@ -224,6 +220,10 @@ class MapViewController: UIViewController {
         currentPopupManager = nil
     }
     
+    private var popupEditing: Cancellable?
+    
+    // MARK: Segues
+    
     override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
 
         if identifier == "modallyPresentRelatedRecordsPopupViewController" {
@@ -253,6 +253,11 @@ class MapViewController: UIViewController {
             }
             else {
                 assertionFailure("A rich popup view controller should not present if any of the above scenarios are not met.")
+            }
+            
+            popupEditing?.cancel()
+            popupEditing = destination.editsMade.sink { [weak self] (result) in
+                self?.refreshCurrentPopup()
             }
         }
         else if let destination = segue.destination as? MaskViewController {

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController+EditingSession.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController+EditingSession.swift
@@ -27,19 +27,12 @@ extension RichPopupViewController {
             
             if let error = error {
                 completion?(error)
-                self.editsMade.send(.failure(error))
                 return
             }
             
             // 2. Persist edits to table
             self.persistEditsToTable { (error) in
                 completion?(error)
-                if let error = error {
-                    self.editsMade.send(.failure(error))
-                }
-                else {
-                    self.editsMade.send(.success(self.popupManager.richPopup))
-                }
             }
         }
     }
@@ -101,12 +94,11 @@ extension RichPopupViewController {
         guard
             let feature = popupManager.popup.geoElement as? AGSArcGISFeature,
             let featureTable = feature.featureTable as? AGSArcGISFeatureTable,
-            featureTable.canDelete(feature)
-        else {
-            let error = NSError.invalidOperation
-            completion?(error)
-            self.editsMade.send(.failure(error))
-            return
+            featureTable.canDelete(feature) else {
+                
+                completion?(NSError.invalidOperation)
+                
+                return
         }
         
         self.popupManager.cancelEditing()
@@ -116,20 +108,13 @@ extension RichPopupViewController {
         }
         catch {
             completion?(error)
-            self.editsMade.send(.failure(error))
             return
         }
         
         // Delete the record from the table.
-        featureTable.performDelete(feature: feature) { [weak self] (error) in
-            guard let self = self else { return }
+        featureTable.performDelete(feature: feature) { (error) in
+            
             completion?(error)
-            if let error = error {
-                self.editsMade.send(.failure(error))
-            }
-            else {
-                self.editsMade.send(.success(self.popupManager.richPopup))
-            }
         }
     }
 }

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController+EditingSession.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController+EditingSession.swift
@@ -27,12 +27,19 @@ extension RichPopupViewController {
             
             if let error = error {
                 completion?(error)
+                self.editsMade.send(.failure(error))
                 return
             }
             
             // 2. Persist edits to table
             self.persistEditsToTable { (error) in
                 completion?(error)
+                if let error = error {
+                    self.editsMade.send(.failure(error))
+                }
+                else {
+                    self.editsMade.send(.success(self.popupManager.richPopup))
+                }
             }
         }
     }
@@ -94,11 +101,12 @@ extension RichPopupViewController {
         guard
             let feature = popupManager.popup.geoElement as? AGSArcGISFeature,
             let featureTable = feature.featureTable as? AGSArcGISFeatureTable,
-            featureTable.canDelete(feature) else {
-                
-                completion?(NSError.invalidOperation)
-                
-                return
+            featureTable.canDelete(feature)
+        else {
+            let error = NSError.invalidOperation
+            completion?(error)
+            self.editsMade.send(.failure(error))
+            return
         }
         
         self.popupManager.cancelEditing()
@@ -108,13 +116,20 @@ extension RichPopupViewController {
         }
         catch {
             completion?(error)
+            self.editsMade.send(.failure(error))
             return
         }
         
         // Delete the record from the table.
-        featureTable.performDelete(feature: feature) { (error) in
-            
+        featureTable.performDelete(feature: feature) { [weak self] (error) in
+            guard let self = self else { return }
             completion?(error)
+            if let error = error {
+                self.editsMade.send(.failure(error))
+            }
+            else {
+                self.editsMade.send(.success(self.popupManager.richPopup))
+            }
         }
     }
 }

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController.swift
@@ -15,6 +15,8 @@
 import UIKit
 import QuickLook
 import ArcGIS
+import Combine
+
 
 class RichPopupViewController: SegmentedViewController {
     
@@ -27,6 +29,10 @@ class RichPopupViewController: SegmentedViewController {
             detailsViewController?.shouldLoadRichPopupRelatedRecords = shouldLoadRichPopupRelatedRecords
         }
     }
+    
+    // MARK: Editing Subject
+    
+    let editsMade = PassthroughSubject<Result<RichPopup, Error>, Never>()
     
     // MARK: Segmented View Controller
     

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController.swift
@@ -239,13 +239,16 @@ class RichPopupViewController: SegmentedViewController {
                 guard let self = self else { return }
                 
                 self.enableUserInteraction()
+                self.updateViewControllerUI(animated: animated)
 
                 if let error = error {
-                                        
                     self.present(simpleAlertMessage: "Could not save record. \(error.localizedDescription)")
+                    self.editsMade.send(.failure(error))
+                }
+                else {
+                    self.editsMade.send(.success(self.popupManager.richPopup))
                 }
                 
-                self.updateViewControllerUI(animated: animated)
             }
         }
         else {
@@ -347,6 +350,13 @@ class RichPopupViewController: SegmentedViewController {
                 guard let self = self else { return }
 
                 self.enableUserInteraction()
+                
+                if let error = error {
+                    self.editsMade.send(.failure(error))
+                }
+                else {
+                    self.editsMade.send(.success(self.popupManager.richPopup))
+                }
                 
                 self.popupManager.conditionallyPerformCustomBehavior { completion?(error) }
             }


### PR DESCRIPTION
This PR resolves the bug, ['Data Collection iOS, deleted pop-up remains in small pop-up view after delete is performed and full pop-up view is dismissed'](https://github.com/ArcGIS/open-source-apps/issues/482).

The solution uses a Combine `PassthroughSubject` to broadcast when edits are made. Subscribers are notified after an add/update/delete operation.