### PR TITLE
Mhd/504 image picker

### DIFF
--- a/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
+++ b/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
@@ -296,13 +296,16 @@ extension ImagePickerPermissions {
             PHPhotoLibrary.requestAuthorization { (status) in
                 DispatchQueue.main.async {
                     var granted: Bool
+                    var shouldOpenSettings: Bool
                     if #available(iOS 14, *) {
                         granted = PHPhotoLibrary.authorizationStatus(for: .readWrite) == .authorized
+                        shouldOpenSettings = !granted
                     }
                     else {
                         granted = PHPhotoLibrary.authorizationStatus() == .authorized
+                        shouldOpenSettings = false
                     }
-                    completion(granted, false)
+                    completion(granted, shouldOpenSettings)
                 }
             }
         }

--- a/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
+++ b/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
@@ -296,16 +296,13 @@ extension ImagePickerPermissions {
             PHPhotoLibrary.requestAuthorization { (status) in
                 DispatchQueue.main.async {
                     var granted: Bool
-                    var shouldOpenSettings: Bool
                     if #available(iOS 14, *) {
                         granted = PHPhotoLibrary.authorizationStatus(for: .readWrite) == .authorized
-                        shouldOpenSettings = !granted
                     }
                     else {
                         granted = PHPhotoLibrary.authorizationStatus() == .authorized
-                        shouldOpenSettings = false
                     }
-                    completion(granted, shouldOpenSettings)
+                    completion(granted, false)
                 }
             }
         }

--- a/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
+++ b/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
@@ -295,7 +295,14 @@ extension ImagePickerPermissions {
         func request(_ completion: @escaping (_ granted: Bool, _ shouldOpenSettings: Bool) -> Void) {
             PHPhotoLibrary.requestAuthorization { (status) in
                 DispatchQueue.main.async {
-                    completion(PHPhotoLibrary.authorizationStatus() == .authorized, false)
+                    var granted: Bool
+                    if #available(iOS 14, *) {
+                        granted = PHPhotoLibrary.authorizationStatus(for: .readWrite) == .authorized
+                    }
+                    else {
+                        granted = PHPhotoLibrary.authorizationStatus() == .authorized
+                    }
+                    completion(granted, false)
                 }
             }
         }

--- a/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
+++ b/data-collection/data-collection/Utilities/ImagePickerPermissions.swift
@@ -133,29 +133,28 @@ public struct ImagePickerPermissions {
                     
                     // Ask to open Settings
                     let viewController = delegate.imagePickerPermissionsRequestsPresentingViewController()
-                    
-                    let alert = UIAlertController(title: "Not Authorized", message: "Go to Settings and authorize the use of the \(permission.title).", preferredStyle: .alert)
-                    
-                    if let settingsUrl = URL(string: UIApplication.openSettingsURLString), UIApplication.shared.canOpenURL(settingsUrl) {
-                        
-                        let settingsAction = UIAlertAction(title: "Settings", style: .default, handler: { _ in
-                            UIApplication.shared.open(settingsUrl)
-                        })
-                        
-                        alert.addAction(settingsAction)
+                    let alert: UIAlertController
+                    if #available(iOS 14, *), PHPhotoLibrary.authorizationStatus(for: .readWrite) == .limited {
+                        alert = notSupportedAlert()
                     }
-                    
-                    let okayAction = UIAlertAction.okay()
-                    alert.addAction(okayAction)
-                    alert.preferredAction = okayAction
-                    
+                    else {
+                        alert = notAuthorizedAlert(permission)
+                    }
                     viewController.present(alert, animated: true)
                     
                     // Finish with no image picker.
                     delegate.imagePickerPermissionsFinishedWith(imagePicker: nil)
                 }
+                else if #available(iOS 14, *) {
+                    if PHPhotoLibrary.authorizationStatus(for: .readWrite) == .limited {
+                        let viewController = delegate.imagePickerPermissionsRequestsPresentingViewController()
+                        let alert = notSupportedAlert()
+                        viewController.present(alert, animated: true)
+                    }
+                    delegate.imagePickerPermissionsFinishedWith(imagePicker: nil)
+                }
                 else {
-                    
+
                     // Finish with no image picker.
                     delegate.imagePickerPermissionsFinishedWith(imagePicker: nil)
                 }
@@ -188,6 +187,31 @@ public struct ImagePickerPermissions {
         alertController.addAction(.cancel())
 
         viewController.present(alertController, animated: true)
+    }
+    
+    fileprivate func notAuthorizedAlert(_ permission: ImagePickerPermission) -> UIAlertController {
+        return permissionAlert(title: "Not Authorized", message: "Go to Settings and authorize the use of the \(permission.title).")
+    }
+    
+    fileprivate func notSupportedAlert() -> UIAlertController {
+        return permissionAlert(title: "Not Supported", message: "The \"Selected Photos\" access option is not currently supported.  Allow access to all photos to add an image attatchment.")
+    }
+    
+    fileprivate func permissionAlert(title: String, message: String) -> UIAlertController {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        
+        if let settingsUrl = URL(string: UIApplication.openSettingsURLString), UIApplication.shared.canOpenURL(settingsUrl) {
+            let settingsAction = UIAlertAction(title: "Settings", style: .default, handler: { _ in
+                UIApplication.shared.open(settingsUrl)
+            })
+            
+            alert.addAction(settingsAction)
+        }
+        
+        let okayAction = UIAlertAction.okay()
+        alert.addAction(okayAction)
+        alert.preferredAction = okayAction
+        return alert
     }
 }
 


### PR DESCRIPTION
This adds an additional check for iOS 14 authorization status after the user selects the desired permissions in-app.  The result of picking "Selected Photos" as the new permissions is the same as if the user picked "None":

![Screen Shot 2021-02-22 at 11 07 26 AM](https://user-images.githubusercontent.com/3998072/108743460-68945980-74fe-11eb-8bab-75a1d7c4809b.png)
