### PR TITLE
Fix online locator authentication challenge.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@
 - Introduces `GlobalAlertQueue`, a utility for enqueueing and presenting alerts in a stand-alone alert window (`UIWindow`). This change improves the reliability of presenting alerts from any app component - context, view, or otherwise.
 - Introduces nuanced offline map icons in Profile view.
 - Dissolves `AppError` protocol, reconsiders errors instead as members of types.
-- Fixes bug where `AppLocator.onlingLocator` issues an authentication challenge amid creating a new feature.
+- Fixes bug where `AddressLocator.onlineLocator` issues an authentication challenge amid creating a new feature.
 
 # Release 1.2.3
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,5 @@
 # Release 1.3
 
-- TODO
 - Introduces an improved `AppContext` state-based architecture and more clear separation of responsibility. This architecture achieves more stability and resolves some found Portal related edge cases. Consult [docs](./docs/README.md#app-context) for more information.
 - Dissolves `AppLocation` into sub-component of `AppContext`.
 - Dissolves `AppGlobals` into `AppContext`.
@@ -11,6 +10,7 @@
 - Introduces `GlobalAlertQueue`, a utility for enqueueing and presenting alerts in a stand-alone alert window (`UIWindow`). This change improves the reliability of presenting alerts from any app component - context, view, or otherwise.
 - Introduces nuanced offline map icons in Profile view.
 - Dissolves `AppError` protocol, reconsiders errors instead as members of types.
+- Fixes bug where `AppLocator.onlingLocator` issues an authentication challenge amid creating a new feature.
 
 # Release 1.2.3
 

--- a/data-collection/data-collection/App Context/AppContext.swift
+++ b/data-collection/data-collection/App Context/AppContext.swift
@@ -38,7 +38,7 @@ class AppContext: NSObject {
             workMode = .online(nil)
         }
         
-        addressLocator = AddressLocator(default: workMode)
+        addressLocator = AddressLocator(default: workMode, credential: nil)
         
         super.init()
         
@@ -99,7 +99,7 @@ class AppContext: NSObject {
         didSet {
             workMode.storeDefaultWorkMode()
             
-            addressLocator.prepareLocator(for: workMode)
+            addressLocator.prepareLocator(for: workMode, credential: portalSession.portal?.credential)
             
             NotificationCenter.default.post(workModeDidChange)
             
@@ -205,6 +205,8 @@ extension AppContext: PortalSessionManagerDelegate {
     
     func portalSessionManager(manager: PortalSessionManager, didChangeStatus status: PortalSessionManager.Status) {
 
+        addressLocator.prepareLocator(for: workMode, credential: manager.portal?.credential)
+        
         NotificationCenter.default.post(portalDidChange)
         
         guard case .online = workMode else { return }


### PR DESCRIPTION
A bug was found.

> The app crashes in a scenario where the app is working **online**, the user is **not authenticated**, and the user attempts to create a new feature thus triggering an authentication challenge to access the world geocoding service. Steps to repro:
> 
> 1. Work online
> 1. Sign-out
> 1. Create a new feature
> 1. Respond to authentication challenge with valid credentials
> 
> At this point the app should crash.

As it was, if the user tried to create a new feature and the online locator was not credentialed, the online locator would issue an authentication challenge. Upon successful authentication, the `AppContext` would rebuild the map using the authenticated portal; doing so would invalidate the created feature because it was a new child of a table that no longer existed in memory.

This PR resolves the bug by allowing a UI -> `AppContext` state change to drive whether the `AppLocator.onlineLocator` is credentialed. This technique gives preference to the user being able to specify when to sign-in and sign out of Portal rather than issuing passive authentication challenges. This technique also resolves the bug because the edge case will never be met.