### PR TITLE
Mhd/fix UI table view alert for layout outside view hierarchy

### DIFF
--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/SegmentedViewController.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/SegmentedViewController.swift
@@ -227,7 +227,9 @@ class SegmentedViewController: UIViewController {
             currentViewController = to
             
             // 6. Finish.
-            view.layoutIfNeeded()
+            if view.superview != nil {
+                view.layoutIfNeeded()
+            }
         }
     }
     


### PR DESCRIPTION
In the console I'm seeing a warning for `UITableViewAlertForLayoutOutsideViewHierarchy`.  This happens when a `layoutIfNeeded` call is applied to a view not yet added to a superview.