### PR TITLE
Updates app with Runtime support for NSItemProvider

### DIFF
--- a/data-collection/data-collection/Rich Popup/Attachments/RichPopupAttachmentsManager.swift
+++ b/data-collection/data-collection/Rich Popup/Attachments/RichPopupAttachmentsManager.swift
@@ -142,9 +142,9 @@ class RichPopupAttachmentsManager: AGSLoadableBase {
                                                       completion: { (_) in dispatchGroup.leave() })
             }
             else {
-                popupAttachmentsManager.addAttachment(with: attachment.attachmentData,
+                popupAttachmentsManager.addAttachment(with: attachment.attachmentData.data,
                                                       name: attachment.name ?? "Attachment",
-                                                      contentType: attachment.attachmentMimeType,
+                                                      contentType: attachment.attachmentData.mimeType,
                                                       preferredSize: attachment.preferredSize)
             }
         }

--- a/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedAttachment.swift
+++ b/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedAttachment.swift
@@ -16,18 +16,26 @@ import ArcGIS
 
 class RichPopupStagedAttachment: NSObject, RichPopupPreviewableAttachment {
     
-    let attachmentData: Data
+    struct AttachmentData {
+        let data: Data
+        let mimeType: String
+    }
     
-    let attachmentMimeType: String
-    
+    let attachmentData: AttachmentData
+        
     var name: String?
     
-    init(data: Data, mimeType: String, name: String?) {
-        
-        self.attachmentData = data
-        self.attachmentMimeType = mimeType
+    init(data: AttachmentData? = nil, name: String? = nil) {
+        if let data = data {
+            self.attachmentData = data
+        }
+        else {
+            self.attachmentData = AttachmentData(
+                data: Data(),
+                mimeType: "application/octet-stream"
+            )
+        }
         self.name = name
-        
         super.init()
     }
     

--- a/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedImagePickerAttachment.swift
+++ b/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedImagePickerAttachment.swift
@@ -37,7 +37,7 @@ class RichPopupStagedImagePickerAttachment: RichPopupStagedAttachment {
 
         guard (info[.editedImage] as? UIImage ?? info[.originalImage] as? UIImage) != nil else { return nil }
         
-        super.init(data: Data() /* will be inferred by SDK */, mimeType: "<will-be-inferred-by-SDK>", name: nil)
+        super.init()
         
         self.previewItemURL = info[.imageURL] as? URL
         

--- a/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedPhotoPickerAttachment.swift
+++ b/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedPhotoPickerAttachment.swift
@@ -14,13 +14,26 @@
 
 import ArcGIS
 
+@available(iOS 14.0, *)
 class RichPopupStagedPhotoPickerAttachment: RichPopupStagedAttachment {
+    
+    private(set) var itemProvider: NSItemProvider
+    
+    init?(itemProvider: NSItemProvider) {
+        guard itemProvider.hasRepresentationConforming(toTypeIdentifier: "public.image", fileOptions: NSItemProviderFileOptions(rawValue: 0)) else {
+            return nil
+        }
+        self.itemProvider = itemProvider
+        super.init(data: Data() /* will be inferred by SDK */, mimeType: "<will-be-inferred-by-SDK>", name: itemProvider.suggestedName)
+    }
     
     override var type: AGSPopupAttachmentType { return .image }
     
     override func generateThumbnail(withSize: Float, scaleMode: AGSImageScaleMode, completion: @escaping (UIImage?) -> Void) {
-        completion(
-            UIImage(data: attachmentData)
-        )
+        itemProvider.loadObject(ofClass: UIImage.self) { (image, error) in
+            if let image = image as? UIImage {
+                completion(image)
+            }
+        }
     }
 }

--- a/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedPhotoPickerAttachment.swift
+++ b/data-collection/data-collection/Rich Popup/Attachments/RichPopupStagedPhotoPickerAttachment.swift
@@ -24,7 +24,7 @@ class RichPopupStagedPhotoPickerAttachment: RichPopupStagedAttachment {
             return nil
         }
         self.itemProvider = itemProvider
-        super.init(data: Data() /* will be inferred by SDK */, mimeType: "<will-be-inferred-by-SDK>", name: itemProvider.suggestedName)
+        super.init(name: itemProvider.suggestedName)
     }
     
     override var type: AGSPopupAttachmentType { return .image }


### PR DESCRIPTION
With the introduction of support for `NSItemProvider` (vis-a-vis `PHPickerViewController`) via the [`AGSPopupAttachmentManager`](https://developers.arcgis.com/ios/api-reference/interface_a_g_s_popup_attachment_manager.html#a497ae60d61d114d01bccab977688038b), this PR defers the burden of handing item provider image loading to the SDK.

