### PR TITLE
Fix for not prompting user to sign in when opening private map.

### DIFF
--- a/data-collection/data-collection/Utilities/GlobalAlertQueue.swift
+++ b/data-collection/data-collection/Utilities/GlobalAlertQueue.swift
@@ -207,4 +207,15 @@ extension UIAlertController {
         alert.addAction(settings)
         return alert
     }
+    
+    static func signInAlert(_ message: String) -> UIAlertController {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let signIn = UIAlertAction(title: "Sign In", style: .default) { (_) in
+            appContext.signIn()
+        }
+        alert.addAction(.cancel())
+        alert.addAction(signIn)
+        alert.preferredAction = signIn
+        return alert
+    }
 }

--- a/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+Map.swift
+++ b/data-collection/data-collection/View Controllers/Map View Controller/MapViewController+Map.swift
@@ -43,7 +43,11 @@ extension MapViewController {
             // If there's an error loading the map we want to inform the user and disable the map.
             if let error = error as NSError? {
                 if AGSServicesErrorCode(rawValue: error.code) == .tokenRequired, !appContext.portalSession.isSignedIn {
-                    showMessage(message: "You must sign in to access this resource.")
+                    showAlert(
+                        .signInAlert("You must sign in to access this resource."),
+                        animated: true,
+                        completion: nil
+                    )
                 }
                 else {
                     showError(error)


### PR DESCRIPTION
This adds back in a "sign in alert" for use when attempting to load a private web map.  This functionality existed v1.2.3, but was removed (inadvertently?) when moving to the `GlobalAlertQueue`.