### PR TITLE
iPad: add attachment from source- action sheet bug

### DIFF
--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupAttachmentsViewController/RichPopupAttachmentsViewController+UITableViewDelegate.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupAttachmentsViewController/RichPopupAttachmentsViewController+UITableViewDelegate.swift
@@ -73,8 +73,8 @@ extension RichPopupAttachmentsViewController /* UITableViewDelegate */ {
         
         tableView.deselectRow(at: indexPath, animated: true)
         
-        if adjustedAttachmentsTableSection(for: indexPath.section) == .addAttachment {
-            delegate?.attachmentsViewControllerDidRequestAddAttachment(self)
+        if let addAttachmentsCell = tableView.cellForRow(at: indexPath) as? PopupAddAttachmentCell {
+            delegate?.attachmentsViewControllerDidRequestAddAttachment(self, source: addAttachmentsCell.accessoryView)
         }
         else if isEditing, let attachment = popupAttachmentsManager.attachment(at: indexPath.row) as? RichPopupStagedAttachment {
             delegate?.attachmentsViewController(self, selectedEditStagedAttachment: attachment)

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupAttachmentsViewController/RichPopupAttachmentsViewController.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupAttachmentsViewController/RichPopupAttachmentsViewController.swift
@@ -16,7 +16,7 @@ import UIKit
 import ArcGIS
 
 protocol RichPopupAttachmentsViewControllerDelegate: AnyObject {
-    func attachmentsViewControllerDidRequestAddAttachment(_ attachmentsViewController: RichPopupAttachmentsViewController)
+    func attachmentsViewControllerDidRequestAddAttachment(_ attachmentsViewController: RichPopupAttachmentsViewController, source view: UIView?)
     func attachmentsViewController(_ attachmentsViewController: RichPopupAttachmentsViewController, selectedEditStagedAttachment attachment: RichPopupStagedAttachment)
     func attachmentsViewController(_ attachmentsViewController: RichPopupAttachmentsViewController, selectedViewAttachmentAtIndex index: Int)
 }

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController+AttachmentPicker.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController+AttachmentPicker.swift
@@ -16,7 +16,7 @@ import ArcGIS
 import PhotosUI
 
 extension RichPopupViewController {
-    func selectMedia() {
+    func selectMedia(view: UIView) {
         let actionSheet = UIAlertController(
             title: nil,
             message: "Select media",
@@ -45,6 +45,7 @@ extension RichPopupViewController {
             actionSheet.addAction(imagePicker)
         }
         actionSheet.addAction(.cancel())
+        actionSheet.popoverPresentationController?.sourceView = view
         present(actionSheet, animated: true, completion: nil)
     }
     

--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController+RichPopupAttachmentsViewControllerDelegate.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController+RichPopupAttachmentsViewControllerDelegate.swift
@@ -17,7 +17,7 @@ import QuickLook
 
 extension RichPopupViewController: RichPopupAttachmentsViewControllerDelegate {
     
-    func attachmentsViewControllerDidRequestAddAttachment(_ attachmentsViewController: RichPopupAttachmentsViewController) {
+    func attachmentsViewControllerDidRequestAddAttachment(_ attachmentsViewController: RichPopupAttachmentsViewController, source view: UIView?) {
         if !isEditing {
             let alert = UIAlertController(
                 title: nil,
@@ -29,7 +29,7 @@ extension RichPopupViewController: RichPopupAttachmentsViewControllerDelegate {
                 // 1. Start editing session
                 self.setEditing(true, animated: true)
                 // 2. Build requests
-                self.selectMedia()
+                self.selectMedia(view: view ?? attachmentsViewController.view)
             }
             alert.addAction(.cancel())
             alert.addAction(edit)
@@ -37,7 +37,7 @@ extension RichPopupViewController: RichPopupAttachmentsViewControllerDelegate {
         }
         else {
             // Request, straight away.
-            selectMedia()
+            selectMedia(view: view ?? attachmentsViewController.view)
         }
     }
     


### PR DESCRIPTION
When editing a pop-up and a user selects 'Add Attachment', the app crashes on iPad because the `.actionSheet` requires us to specify a `actionSheet.popoverPresentationController?.sourceView`.

This PR fixes this by supplying the accessory view from the 'Add Attachment' cell (the camera icon) and falls back to the view controller's view if for some reason the accessory view is missing (it shouldn't be!)