### PR TITLE
Fix for [iOS] Can't "Cancel" adding an attachment from Image Library (iOS 14) #573

### DIFF
--- a/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController+AttachmentPicker.swift
+++ b/data-collection/data-collection/View Controllers/Rich Popup View Controllers/Rich Popup View Controller/RichPopupViewController+AttachmentPicker.swift
@@ -211,13 +211,20 @@ fileprivate struct UnknownError: LocalizedError {
 @available(iOS 14.0, *)
 extension RichPopupViewController: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
-        guard !results.isEmpty else { return }
         guard !isProcessingNewAttachmentImage else { return }
         isProcessingNewAttachmentImage = true
-        let attachments = results.compactMap { RichPopupStagedPhotoPickerAttachment(itemProvider: $0.itemProvider) }
-        picker.dismiss(animated: true) {
-            attachments.forEach { self.attachmentsViewController.addAttachment($0) }
-            self.isProcessingNewAttachmentImage = false
+        if results.isEmpty {
+            // User canceled...
+            picker.dismiss(animated: true) {
+                self.isProcessingNewAttachmentImage = false
+            }
+        }
+        else {
+            let attachments = results.compactMap { RichPopupStagedPhotoPickerAttachment(itemProvider: $0.itemProvider) }
+            picker.dismiss(animated: true) {
+                attachments.forEach { self.attachmentsViewController.addAttachment($0) }
+                self.isProcessingNewAttachmentImage = false
+            }
         }
     }
 }


### PR DESCRIPTION
The one delegate method for the `PHPickerViewController` is designed to signify both Cancel and Accept operations.  Make sure we handle these two cases.