### PR TITLE
Subtitle update

### DIFF
--- a/data-collection/data-collection/View Controllers/Identify Results View Controller/IdentifyResultsViewController.swift
+++ b/data-collection/data-collection/View Controllers/Identify Results View Controller/IdentifyResultsViewController.swift
@@ -111,6 +111,7 @@ class IdentifyResultsViewController: UITableViewController, FloatingPanelEmbedda
 
         guard let destination = segue.destination as? RichPopupViewController else { return }
         destination.popupManager = popupManager
+        subtitles.removeObject(forKey: richPopup)
 
         popupEditing?.cancel()
         popupEditing = destination.editsMade.sink { [weak self] (result) in


### PR DESCRIPTION
Force subtitle for selected row to be regenerated next time through, just in case there were any edits to the feature.

@esreli This was the best quick-fix for the subtitle not being updated.  I wanted to use the `EditsMade` mechanism, but because of the hierarchical nature of the `PopupViewController` -> `PopupDetailViewController` UI stack, it was not easy, straightforward, or risk free.

With this fix, when the cell represented the edited feature is reloaded, the subtitle will update.  So now the subtitle and the swatch will behave the same.